### PR TITLE
공통 API 응답 모델 구현

### DIFF
--- a/Inside-Out/src/main/java/com/goorm/insideout/global/response/ApiResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/response/ApiResponse.java
@@ -1,0 +1,35 @@
+package com.goorm.insideout.global.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	private Metadata metadata; // 주로 결과의 개수를 담는다.
+
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	private List<T> results; // 여러 개의 결과를 반환할 때 사용한다.
+
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	private T data; // 단일 데이터 객체나 기타 응답 데이터를 담는 필드이다.
+
+	public ApiResponse(List<T> results) {
+		this.metadata = new Metadata(results.size());
+		this.results = results;
+	}
+
+	public ApiResponse(T data) {
+		this.data = data;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	private static class Metadata {
+		private int resultCount = 0;
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/global/response/ApiResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/response/ApiResponse.java
@@ -24,7 +24,8 @@ public class ApiResponse<T> {
 	}
 
 	public ApiResponse(T data) {
-		this.data = data;
+		this.metadata = new Metadata(1);
+		this.results = List.of(data);
 	}
 
 	@Getter


### PR DESCRIPTION
### #️⃣ 연관된 이슈

#19 

### 📝 작업 내용

- 공통 API 응답 모델을 구현했습니다.
  - `metadata`, `results`, `data` 필드로 구성되어 있습니다.
  - `metadata`는 메타정보이며, 주로 `results`의 길이, 즉 결과의 개수를 뜻합니다.
  - `results`는 데이터 목록을 뜻합니다. (ex. 사용자 목록 조회 API에서의 사용자 목록)
  - `data`는 단일 데이터를 뜻합니다. (ex. 한 명의 사용자 조회 결과)

- `code`, `message` 등의 필드로 이루어진 에러 응답은 곧 구현될 예정입니다.
 
### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)