### PR TITLE
Feat/기본적인 채팅 구현 #28

### DIFF
--- a/Inside-Out/build.gradle
+++ b/Inside-Out/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/controller/ChatController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/controller/ChatController.java
@@ -1,0 +1,26 @@
+package com.goorm.insideout.chat.controller;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goorm.insideout.chat.dto.request.ChatRequestDTO;
+import com.goorm.insideout.chat.service.ChatService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+
+public class ChatController {
+	private final ChatService chatService;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	@MessageMapping("/chatRoom/{chatRoomId}")
+	public void messageHandler(@DestinationVariable("chatRoomId") Long roomId, ChatRequestDTO message) {
+		chatService.createChat(roomId, message);
+		messagingTemplate.convertAndSend("/sub/chatRoom/" + roomId, message);
+	}
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/controller/ChatController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/controller/ChatController.java
@@ -1,26 +1,39 @@
 package com.goorm.insideout.chat.controller;
 
+import java.security.Principal;
+
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goorm.insideout.chat.domain.Chat;
 import com.goorm.insideout.chat.dto.request.ChatRequestDTO;
+import com.goorm.insideout.chat.dto.response.ChatResponseDTO;
 import com.goorm.insideout.chat.service.ChatService;
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-
 public class ChatController {
 	private final ChatService chatService;
 	private final SimpMessageSendingOperations messagingTemplate;
 
 	@MessageMapping("/chatRoom/{chatRoomId}")
-	public void messageHandler(@DestinationVariable("chatRoomId") Long roomId, ChatRequestDTO message) {
-		chatService.createChat(roomId, message);
-		messagingTemplate.convertAndSend("/sub/chatRoom/" + roomId, message);
-	}
+	public ApiResponse messageHandler(@DestinationVariable("chatRoomId") Long roomId,
+		@RequestBody ChatRequestDTO chatRequestDTO, Principal principal) {
 
+		Chat chat = chatService.createChat(roomId, chatRequestDTO, principal);
+		ChatResponseDTO chatResponseDTO = ChatResponseDTO.builder()
+			.content(chat.getContent())
+			.sender(chat.getUser().getName())
+			.sendTime(chat.getSendTime()).build();
+		messagingTemplate.convertAndSend("/sub/chatRoom/" + roomId, chatResponseDTO);
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+
+	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/domain/Chat.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/domain/Chat.java
@@ -2,10 +2,7 @@ package com.goorm.insideout.chat.domain;
 
 import static jakarta.persistence.FetchType.*;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
-
-import org.hibernate.annotations.CreationTimestamp;
 
 import com.goorm.insideout.chatroom.domain.ChatRoom;
 import com.goorm.insideout.user.domain.User;
@@ -51,6 +48,5 @@ public class Chat {
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "id", nullable = false)
 	private User user;
-
 
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/domain/Chat.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/domain/Chat.java
@@ -1,0 +1,56 @@
+package com.goorm.insideout.chat.domain;
+
+import static jakarta.persistence.FetchType.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "CHATS")
+public class Chat {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chat_id", updatable = false, nullable = false, unique = true)
+	private Long id;
+
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	@Column(name = "send_time", nullable = false)
+	private LocalDateTime sendTime;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "chat_room_id", nullable = false)
+	private ChatRoom chatRoom;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "id", nullable = false)
+	private User user;
+
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/request/ChatRequestDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/request/ChatRequestDTO.java
@@ -1,0 +1,13 @@
+package com.goorm.insideout.chat.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatRequestDTO {
+	private Long userId;
+	private String content;
+
+}
+

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/request/ChatRequestDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/request/ChatRequestDTO.java
@@ -6,8 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ChatRequestDTO {
-	private Long userId;
 	private String content;
-
 }
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/response/ChatResponseDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/response/ChatResponseDTO.java
@@ -1,0 +1,4 @@
+package com.goorm.insideout.chat.dto.response;
+
+public class ChatResponseDTO {
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/response/ChatResponseDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/response/ChatResponseDTO.java
@@ -1,4 +1,17 @@
 package com.goorm.insideout.chat.dto.response;
 
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
 public class ChatResponseDTO {
+	private String content;
+	private LocalDateTime sendTime;
+	private String sender;
+
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/repository/ChatRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/repository/ChatRepository.java
@@ -1,0 +1,9 @@
+package com.goorm.insideout.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goorm.insideout.chat.domain.Chat;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/service/ChatService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/service/ChatService.java
@@ -1,0 +1,46 @@
+package com.goorm.insideout.chat.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import com.goorm.insideout.chat.domain.Chat;
+import com.goorm.insideout.chat.dto.request.ChatRequestDTO;
+import com.goorm.insideout.chat.repository.ChatRepository;
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
+import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatRepository chatRepository;
+	private final UserRepository userRepository;
+
+	public void createChat(Long roomId, ChatRequestDTO message) {
+
+		// 채팅을 작성한 작성자 찾기
+		User sender = userRepository.findById(message.getUserId())
+			.orElseThrow(() -> new RuntimeException("User not found"));
+
+		// 채팅방 찾기
+		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+			.orElseThrow(() -> new RuntimeException("Chat room not found"));
+
+		// 채팅 엔티티 생성
+		LocalDateTime now = LocalDateTime.now();
+		Chat chat = Chat.builder()
+			.content(message.getContent())
+			.chatRoom(chatRoom)
+			.user(sender)
+			.sendTime(now)
+			.build();
+		chatRepository.save(chat);
+
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/service/ChatService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/service/ChatService.java
@@ -1,14 +1,18 @@
 package com.goorm.insideout.chat.service;
 
+import java.security.Principal;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.goorm.insideout.chat.domain.Chat;
 import com.goorm.insideout.chat.dto.request.ChatRequestDTO;
 import com.goorm.insideout.chat.repository.ChatRepository;
 import com.goorm.insideout.chatroom.domain.ChatRoom;
 import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.exception.ModongException;
 import com.goorm.insideout.user.domain.User;
 import com.goorm.insideout.user.repository.UserRepository;
 
@@ -21,26 +25,38 @@ public class ChatService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatRepository chatRepository;
 	private final UserRepository userRepository;
-
-	public void createChat(Long roomId, ChatRequestDTO message) {
+	@Transactional
+	public Chat createChat(Long roomId, ChatRequestDTO message, Principal principal) {
 
 		// 채팅을 작성한 작성자 찾기
-		User sender = userRepository.findById(message.getUserId())
-			.orElseThrow(() -> new RuntimeException("User not found"));
+		User sender = getSender(principal.getName());
 
 		// 채팅방 찾기
-		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-			.orElseThrow(() -> new RuntimeException("Chat room not found"));
+		ChatRoom chatRoom = getChatRoom(roomId);
 
 		// 채팅 엔티티 생성
-		LocalDateTime now = LocalDateTime.now();
+
 		Chat chat = Chat.builder()
 			.content(message.getContent())
 			.chatRoom(chatRoom)
 			.user(sender)
-			.sendTime(now)
+			.sendTime(LocalDateTime.now())
 			.build();
-		chatRepository.save(chat);
+		return chatRepository.save(chat);
 
 	}
+
+	private User getSender(String email) {
+		//해당 이메일로 가입한 유저가 존재하는지 확인
+		return userRepository.findByEmail(email)
+			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
+	}
+
+	private ChatRoom getChatRoom(Long roomId) {
+		//해당 PK에 맞는 채팅방 검색
+		return chatRoomRepository.findById(roomId)
+			.orElseThrow(() -> ModongException.from(ErrorCode.CHATROOM_NOT_FOUND));
+
+	}
+
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketConfig.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketConfig.java
@@ -1,26 +1,38 @@
 package com.goorm.insideout.chat.websocket;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import lombok.RequiredArgsConstructor;
+
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
-
+	private final WebSocketInterceptor webSocketInterceptor;
+	private final WebSocketErrorHandler chatErrorHandler;
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws-stomp").setAllowedOriginPatterns("*");
 		//.withSockJS();
+		registry.setErrorHandler(chatErrorHandler);
 	}
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
-
-		registry.enableSimpleBroker("/sub");
-
+		registry.enableSimpleBroker("/sub","/queue");
 		registry.setApplicationDestinationPrefixes("/pub");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(webSocketInterceptor);
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketConfig.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.goorm.insideout.chat.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws-stomp").setAllowedOriginPatterns("*");
+		//.withSockJS();
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+
+		registry.enableSimpleBroker("/sub");
+
+		registry.setApplicationDestinationPrefixes("/pub");
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketErrorHandler.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketErrorHandler.java
@@ -1,0 +1,58 @@
+package com.goorm.insideout.chat.websocket;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompConversionException;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import com.goorm.insideout.global.exception.ModongException;
+
+@Component
+public class WebSocketErrorHandler extends StompSubProtocolErrorHandler {
+	public WebSocketErrorHandler() {
+		super();
+	}
+
+	@Override
+	public Message<byte[]> handleClientMessageProcessingError(@Nullable Message<byte[]> clientMessage,
+		@Nullable Throwable ex) {
+		if (ex instanceof MessageDeliveryException) {
+			ex = ex.getCause();
+		}
+		if (ex instanceof ModongException) {
+			return handleModongException(clientMessage, (ModongException)ex);
+		}
+		if (ex instanceof StompConversionException) {
+			return handleStompConversionException(clientMessage, (StompConversionException)ex);
+		}
+		return super.handleClientMessageProcessingError(clientMessage, ex);
+	}
+
+	// ModongException 처리
+	private Message<byte[]> handleModongException(Message<byte[]> clientMessage, ModongException ex) {
+		String errorMessage = ex.GetMessage();
+		return createErrorMessage(errorMessage);
+	}
+
+	private Message<byte[]> handleStompConversionException(Message<byte[]> clientMessage, StompConversionException ex) {
+		String errorMessage = "Invalid STOMP header format: " + ex.getMessage();
+		return createErrorMessage(errorMessage);
+	}
+
+	// 에러 메시지 생성
+	private Message<byte[]> createErrorMessage(String errorMessage) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+		accessor.setMessage(errorMessage);
+		accessor.setLeaveMutable(true);
+
+		return MessageBuilder.createMessage(errorMessage.getBytes(StandardCharsets.UTF_8),
+			accessor.getMessageHeaders());
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketEventListener.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketEventListener.java
@@ -1,0 +1,28 @@
+package com.goorm.insideout.chat.websocket;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class WebSocketEventListener {
+
+	@EventListener
+	public void handleWebSocketConnectListener(SessionConnectEvent event) {
+		StompHeaderAccessor headers = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = headers.getSessionId();
+		log.debug("WebSocket Connected: {}", sessionId);
+	}
+
+	@EventListener
+	public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+		StompHeaderAccessor headers = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = headers.getSessionId();
+		log.debug("WebSocket Disconnected: {}", sessionId);
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketInterceptor.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/websocket/WebSocketInterceptor.java
@@ -1,0 +1,71 @@
+package com.goorm.insideout.chat.websocket;
+
+import static com.goorm.insideout.global.exception.ErrorCode.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.goorm.insideout.auth.utils.JWTUtil;
+import com.goorm.insideout.global.exception.ModongException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+@RequiredArgsConstructor
+@Component
+public class WebSocketInterceptor implements ChannelInterceptor {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebSocketInterceptor.class);
+
+	private final JWTUtil jwtUtil;
+
+	@SneakyThrows
+	@Override
+	public Message<?> preSend( Message<?> message,  MessageChannel channel) {
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+		if (accessor == null) {
+			logger.error("MessageHeaderAccessor is null");
+			throw ModongException.from(INVALID_STOMP_MESSAGE_HEADER);
+		}
+
+		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+			String authToken = accessor.getFirstNativeHeader("Authorization");
+			logger.info("Authorization Header: {}", authToken);
+
+			if (authToken == null || !authToken.startsWith("Bearer ")) {
+				logger.error("Invalid Authorization Header");
+				throw ModongException.from(INVALID_AUTH_TOKEN);
+			}
+
+			String token = authToken.substring(7);
+
+			if (!jwtUtil.validateToken(token)) {
+				logger.error("Invalid JWT token");
+				throw ModongException.from(INVALID_AUTH_TOKEN);
+			}
+
+			if (jwtUtil.isExpired(token)) {
+				logger.error("Expired JWT token");
+				throw ModongException.from(EXPIRED_AUTH_TOKEN);
+			}
+
+			String userEmail = jwtUtil.getUserEmail(token);
+
+			UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+				userEmail, null, null);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			accessor.setUser(authentication);
+		}
+		return message;
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/domain/ChatRoom.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/domain/ChatRoom.java
@@ -1,0 +1,55 @@
+package com.goorm.insideout.chatroom.domain;
+
+import static jakarta.persistence.FetchType.*;
+
+import java.sql.Timestamp;
+import java.util.Set;
+
+import com.goorm.insideout.chat.domain.Chat;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Setter
+@Getter
+@Table(name = "CHAT_ROOMS")
+public class ChatRoom {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chat_room_id")
+	private long id;
+
+	@Column(name = "title", updatable = false, nullable = false, unique = true)
+	private String title;
+
+	@Column(name = "created_at", nullable = false)
+	private Timestamp createdAt;
+
+	@Column(name = "type", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private ChatRoomType type;
+
+	@Column(name = "associated_id", nullable = false)
+	private long associatedId; // 동아리 또는 모임의 ID
+
+	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = LAZY)
+	private Set<Chat> messages;
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/domain/ChatRoomType.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/domain/ChatRoomType.java
@@ -1,0 +1,6 @@
+package com.goorm.insideout.chatroom.domain;
+
+public enum ChatRoomType {
+	CLUB, // 동아리
+	MEETING // 모임
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/repository/ChatRoomRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,11 @@
+package com.goorm.insideout.chatroom.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+	Optional<ChatRoom> findById(long id);
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/global/exception/ErrorCode.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/exception/ErrorCode.java
@@ -47,13 +47,16 @@ public enum ErrorCode {
 	MEETING_NOT_MEMBER(HttpStatus.FORBIDDEN, "모임의 멤버가 아닙니다."),
 
 	// chat
-	CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
+	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
 	CHAT_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 채팅방입니다."),
 	CHAT_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "채팅방에 가입되어 있지 않습니다."),
 	CHAT_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 가입된 채팅방입니다."),
 	CHATROOM_NOT_ALLOWED(HttpStatus.FORBIDDEN, "채팅방에 접근할 수 없습니다."),
 	CHAT_NOT_AVAILABLE(HttpStatus.FORBIDDEN, "메시지를 보낼 수 없습니다."),
 	NOT_ALLOWED_TO_DELETE_CHATROOM(HttpStatus.FORBIDDEN, "채팅방을 삭제할 수 없습니다."),
+
+	// stomp
+	INVALID_STOMP_MESSAGE_HEADER(HttpStatus.NOT_FOUND,"유효한 헤더가 아닙니다"),
 
 	// others
 	REQUEST_OK(HttpStatus.OK, "올바른 요청입니다."),


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #28

### 📝 작업 내용

- 웹 소켓을 연결합니다.
  - WebSocketInterceptor를 통해 stomp의 헤더값을 가져옵니다. 거기서 JWT 인증을 합니다.
  - WebSocketErrorHandler에서 에러났을때 예외처리를 하여 메세지를 던져줍니다.
- 실시간 채팅을 합니다.
  - MessageMapping을 통하여 url에 해당하면 함수가 실행됩니다.
  - MessagingTemplate를 사용하여 해당하는 url을 구독하고 있는 사람들에게 chatReponseDTO가 실시간으로 전달됩니다.
- 채팅을 저장합니다.
  - createChat 메서드에서 db에 저장하고 예외처리를 합니다.

### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)
- 에러처리 부분이 다르다보니 따로 webSocketErrorHandler를 만들었습니다.
- RestControllerAdvice에 해당안되어 WebSocketInterceptor에 로그를 찍었는데 어떤 방법이 좋은지 리뷰 부탁드립니다.