### PR TITLE
모임 CRUD 기능 구현

### DIFF
--- a/Inside-Out/src/main/java/com/goorm/insideout/global/exception/ErrorCode.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/exception/ErrorCode.java
@@ -44,8 +44,9 @@ public enum ErrorCode {
 	MEETING_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 모임입니다."),
 	MEETING_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "모임에 가입되어 있지 않습니다."),
 	MEETING_ALREADY_JOINED(HttpStatus.CONFLICT, "이미 가입된 모임입니다."),
-	MEETING_NOT_OWNER(HttpStatus.FORBIDDEN, "모임의 호스트가 아닙니다."),
+	MEETING_NOT_HOST(HttpStatus.FORBIDDEN, "모임의 호스트가 아닙니다."),
 	MEETING_NOT_MEMBER(HttpStatus.FORBIDDEN, "모임의 멤버가 아닙니다."),
+	MEETING_GENDER_RATIO_INVALID(HttpStatus.BAD_REQUEST, "성별 비율이 올바르지 않습니다."),
 
 	// chat
 	CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),

--- a/Inside-Out/src/main/java/com/goorm/insideout/global/handler/GlobalExceptionHandler.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/handler/GlobalExceptionHandler.java
@@ -43,8 +43,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
           at com.festago.admin.presentation.AdminController.getError(AdminController.java:129)
      */
 
-	@ExceptionHandler(RuntimeException.class)
-	public ApiResponse<Void> handle(ModongException exception, HttpServletRequest request) {
+	@ExceptionHandler(ModongException.class)
+	public ApiResponse handle(ModongException exception, HttpServletRequest request) {
 		logInfo(exception, request);
 		return new ApiResponse<>(exception);
 	}

--- a/Inside-Out/src/main/java/com/goorm/insideout/global/response/ApiResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/response/ApiResponse.java
@@ -2,6 +2,7 @@ package com.goorm.insideout.global.response;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -27,10 +28,10 @@ public class ApiResponse<T> {
 		this.results = results;
 	}
 
-	public ApiResponse(List<T> results, Pageable pageable) {
+	public ApiResponse(Page<T> results) {
 		this.status = new Status(ErrorCode.REQUEST_OK);
-		this.metadata = new Metadata(results.size(), pageable);
-		this.results = results;
+		this.metadata = new Metadata(results.getContent().size(), results.getPageable());
+		this.results = results.getContent();
 	}
 
 	public ApiResponse(T data) {

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
@@ -1,0 +1,143 @@
+package com.goorm.insideout.meeting.controller;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.goorm.insideout.auth.dto.CustomUserDetails;
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.response.ApiResponse;
+import com.goorm.insideout.meeting.dto.request.MeetingCreateRequest;
+import com.goorm.insideout.meeting.dto.request.MeetingUpdateRequest;
+import com.goorm.insideout.meeting.dto.response.MeetingResponse;
+import com.goorm.insideout.meeting.service.MeetingService;
+import com.goorm.insideout.user.domain.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MeetingController {
+	private final MeetingService meetingService;
+
+
+	// 모임 생성
+	@PostMapping("/meetings")
+	public ApiResponse<String> createMeeting(
+		@RequestBody MeetingCreateRequest request,
+		@RequestPart(value = "meetingImage", required = false) List<MultipartFile> multipartFiles,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails
+	) {
+		User user = customUserDetails.getUser();
+		meetingService.save(request, user);
+
+		return new ApiResponse<>("성공성공성공");
+	}
+
+	// 모임 단건 조회
+	@GetMapping("/meetings/{meetingId}")
+	public ApiResponse<MeetingResponse> findById(@PathVariable Long meetingId) {
+		MeetingResponse meetingResponse = meetingService.findById(meetingId);
+
+		return new ApiResponse<>(meetingResponse);
+	}
+
+	// 나의 승인대기 모임 목록 조회
+	@GetMapping("/meetings/pending")
+	public ApiResponse<MeetingResponse> findPendingMeetins(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		Pageable pageable
+	) {
+		Long userId = customUserDetails.getUser().getId();
+		Page<MeetingResponse> pendingMeetings = meetingService.findPendingMeetings(userId, pageable);
+
+		return new ApiResponse<>(pendingMeetings);
+	}
+
+	// 나의 참여중인 모임 목록 조회
+	@GetMapping("/meetings/participating")
+	public ApiResponse<MeetingResponse> findParticipatingMeetings(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		Pageable pageable
+	) {
+		Long userId = customUserDetails.getUser().getId();
+		Page<MeetingResponse> pendingMeetings = meetingService.findParticipatingMeetings(userId, pageable);
+
+		return new ApiResponse<>(pendingMeetings);
+	}
+
+	// 나의 종료된 모임 목록 조회
+	@GetMapping("/meetings/ended")
+	public ApiResponse<MeetingResponse> findClosedMeetings(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		Pageable pageable
+	) {
+		Long userId = customUserDetails.getUser().getId();
+		Page<MeetingResponse> pendingMeetings = meetingService.findEndedMeetings(userId, pageable);
+
+		return new ApiResponse<>(pendingMeetings);
+	}
+
+	// 나의 운영중인 모임 목록 조회
+	@GetMapping("/meetings/running")
+	public ApiResponse<MeetingResponse> findRunningMeetings(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		Pageable pageable
+	) {
+		Long userId = customUserDetails.getUser().getId();
+		Page<MeetingResponse> pendingMeetings = meetingService.findRunningMeetings(userId, pageable);
+
+		return new ApiResponse<>(pendingMeetings);
+	}
+
+	// 모임 정보 수정
+	@PatchMapping("/meetings/{meetingId}")
+	public ApiResponse updateMeeting(
+		@PathVariable Long meetingId,
+		@RequestBody MeetingUpdateRequest request,
+		@RequestPart(value = "meetingImage", required = false) List<MultipartFile> multipartFiles,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails
+	) {
+		User user = customUserDetails.getUser();
+		meetingService.updateById(user, meetingId, request);
+
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+
+	// 모임 삭제
+	@DeleteMapping("/meetings/{meetingId}")
+	public ApiResponse deleteMeeting(
+		@PathVariable Long meetingId,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails
+	) {
+		User user = customUserDetails.getUser();
+		meetingService.deleteById(user, meetingId);
+
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+
+	// 모임 종료
+	@PatchMapping("/meetings/{meetingId}/end")
+	public ApiResponse endMeeting(
+		@PathVariable Long meetingId,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails
+	) {
+		User user = customUserDetails.getUser();
+		meetingService.endMeeting(user, meetingId);
+
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
@@ -23,7 +23,6 @@ import com.goorm.insideout.meeting.dto.request.MeetingCreateRequest;
 import com.goorm.insideout.meeting.dto.request.MeetingUpdateRequest;
 import com.goorm.insideout.meeting.dto.response.MeetingResponse;
 import com.goorm.insideout.meeting.service.MeetingService;
-import com.goorm.insideout.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -41,8 +40,7 @@ public class MeetingController {
 		@RequestPart(value = "meetingImage", required = false) List<MultipartFile> multipartFiles,
 		@AuthenticationPrincipal CustomUserDetails customUserDetails
 	) {
-		User user = customUserDetails.getUser();
-		meetingService.save(request, user);
+		meetingService.save(request, customUserDetails);
 
 		return new ApiResponse<>("성공성공성공");
 	}
@@ -57,12 +55,11 @@ public class MeetingController {
 
 	// 나의 승인대기 모임 목록 조회
 	@GetMapping("/meetings/pending")
-	public ApiResponse<MeetingResponse> findPendingMeetins(
+	public ApiResponse<MeetingResponse> findPendingMeetings(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		Pageable pageable
 	) {
-		Long userId = customUserDetails.getUser().getId();
-		Page<MeetingResponse> pendingMeetings = meetingService.findPendingMeetings(userId, pageable);
+		Page<MeetingResponse> pendingMeetings = meetingService.findPendingMeetings(customUserDetails, pageable);
 
 		return new ApiResponse<>(pendingMeetings);
 	}
@@ -73,8 +70,7 @@ public class MeetingController {
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		Pageable pageable
 	) {
-		Long userId = customUserDetails.getUser().getId();
-		Page<MeetingResponse> pendingMeetings = meetingService.findParticipatingMeetings(userId, pageable);
+		Page<MeetingResponse> pendingMeetings = meetingService.findParticipatingMeetings(customUserDetails, pageable);
 
 		return new ApiResponse<>(pendingMeetings);
 	}
@@ -85,8 +81,7 @@ public class MeetingController {
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		Pageable pageable
 	) {
-		Long userId = customUserDetails.getUser().getId();
-		Page<MeetingResponse> pendingMeetings = meetingService.findEndedMeetings(userId, pageable);
+		Page<MeetingResponse> pendingMeetings = meetingService.findEndedMeetings(customUserDetails, pageable);
 
 		return new ApiResponse<>(pendingMeetings);
 	}
@@ -97,8 +92,7 @@ public class MeetingController {
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		Pageable pageable
 	) {
-		Long userId = customUserDetails.getUser().getId();
-		Page<MeetingResponse> pendingMeetings = meetingService.findRunningMeetings(userId, pageable);
+		Page<MeetingResponse> pendingMeetings = meetingService.findRunningMeetings(customUserDetails, pageable);
 
 		return new ApiResponse<>(pendingMeetings);
 	}
@@ -111,8 +105,7 @@ public class MeetingController {
 		@RequestPart(value = "meetingImage", required = false) List<MultipartFile> multipartFiles,
 		@AuthenticationPrincipal CustomUserDetails customUserDetails
 	) {
-		User user = customUserDetails.getUser();
-		meetingService.updateById(user, meetingId, request);
+		meetingService.updateById(customUserDetails, meetingId, request);
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
@@ -123,8 +116,7 @@ public class MeetingController {
 		@PathVariable Long meetingId,
 		@AuthenticationPrincipal CustomUserDetails customUserDetails
 	) {
-		User user = customUserDetails.getUser();
-		meetingService.deleteById(user, meetingId);
+		meetingService.deleteById(customUserDetails, meetingId);
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
@@ -135,8 +127,7 @@ public class MeetingController {
 		@PathVariable Long meetingId,
 		@AuthenticationPrincipal CustomUserDetails customUserDetails
 	) {
-		User user = customUserDetails.getUser();
-		meetingService.endMeeting(user, meetingId);
+		meetingService.endMeeting(customUserDetails, meetingId);
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/ApprovalStatus.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/ApprovalStatus.java
@@ -1,0 +1,15 @@
+package com.goorm.insideout.meeting.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ApprovalStatus {
+
+	APPROVED("승인"),
+	DENIED("거절"),
+	PENDING("대기");
+
+	private final String name;
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Category.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Category.java
@@ -1,8 +1,10 @@
 package com.goorm.insideout.meeting.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum Category {
 
 	SOCIAL("사교/취미"),
@@ -10,8 +12,4 @@ public enum Category {
 	STUDY("스터디");
 
 	private final String name;
-
-	Category(String name) {
-		this.name = name;
-	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/GenderRatio.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/GenderRatio.java
@@ -1,0 +1,39 @@
+package com.goorm.insideout.meeting.domain;
+
+import java.util.Arrays;
+
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.exception.ModongException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GenderRatio {
+
+	ONLY_MALE(10, 0), // 남자만
+	ONLY_FEMALE(0, 10), // 여자만
+
+	ONE_TO_NINE(1, 9),
+	TWO_TO_EIGHT(2, 8),
+	THREE_TO_SEVEN(3, 7),
+	FOUR_TO_SIX(4, 6),
+	FIVE_TO_FIVE(5, 5),
+	SIX_TO_FOUR(6, 4),
+	SEVEN_TO_THREE(7, 3),
+	EIGHT_TO_TWO(8, 2),
+	NINE_TO_ONE(9, 1),
+
+	IRRELEVANT(0, 0); // 성별 비율 무관
+
+	private final int maleRatio;
+	private final int femaleRatio;
+
+	public static GenderRatio valueOf(int maleRatio, int femaleRatio) {
+		return Arrays.stream(GenderRatio.values())
+			.filter(genderRatio -> genderRatio.maleRatio == maleRatio && genderRatio.femaleRatio == femaleRatio)
+			.findFirst()
+			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_GENDER_RATIO_INVALID));
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/GenderRatio.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/GenderRatio.java
@@ -12,18 +12,18 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GenderRatio {
 
-	ONLY_MALE(10, 0), // 남자만
-	ONLY_FEMALE(0, 10), // 여자만
+	ONLY_MALE(100, 0), // 남자만
+	ONLY_FEMALE(0, 100), // 여자만
 
-	ONE_TO_NINE(1, 9),
-	TWO_TO_EIGHT(2, 8),
-	THREE_TO_SEVEN(3, 7),
-	FOUR_TO_SIX(4, 6),
-	FIVE_TO_FIVE(5, 5),
-	SIX_TO_FOUR(6, 4),
-	SEVEN_TO_THREE(7, 3),
-	EIGHT_TO_TWO(8, 2),
-	NINE_TO_ONE(9, 1),
+	ONE_TO_NINE(10, 90),
+	TWO_TO_EIGHT(20, 80),
+	THREE_TO_SEVEN(30, 70),
+	FOUR_TO_SIX(40, 60),
+	FIVE_TO_FIVE(50, 50),
+	SIX_TO_FOUR(60, 40),
+	SEVEN_TO_THREE(70, 30),
+	EIGHT_TO_TWO(80, 20),
+	NINE_TO_ONE(90, 10),
 
 	IRRELEVANT(0, 0); // 성별 비율 무관
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Level.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Level.java
@@ -1,8 +1,10 @@
 package com.goorm.insideout.meeting.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum Level {
 
 	BEGINNER("하", "해당 스포츠에 이제 막 입문했거나 경험이 적은 사용자에요."),
@@ -12,9 +14,4 @@ public enum Level {
 
 	private final String name;
 	private final String description;
-
-	Level(String name, String description) {
-		this.name = name;
-		this.description = description;
-	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -6,16 +6,23 @@ import java.util.List;
 
 import com.goorm.insideout.image.domain.Image;
 import com.goorm.insideout.like.domain.MeetingLike;
+import com.goorm.insideout.user.domain.User;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 @Entity
@@ -86,6 +93,9 @@ public class Meeting {
 	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "user_id")
 	private User host;
+
+	@OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
+	private List<MeetingUser> meetingUsers = new ArrayList<>();
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "place_id")

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -105,6 +105,51 @@ public class Meeting {
 	@JoinColumn(name = "place_id")
 	private Place place;
 
+	/**
+	 * 생성 메서드
+	 */
+	public static Meeting createMeeting (
+		String title,
+		String description,
+		Category category,
+		int participantsNumber,
+		int participantLimit,
+		String rule,
+		String joinQuestion,
+		LocalDateTime schedule,
+		Level level,
+		int minimumAge,
+		int maximumAge,
+		GenderRatio genderRatio,
+		boolean hasMembershipFee,
+		int membershipFee,
+		String hobby,
+		User host,
+		Place place
+	) {
+		Meeting meeting = new Meeting();
+
+		meeting.title = title;
+		meeting.description = description;
+		meeting.category = category;
+		meeting.participantsNumber = participantsNumber;
+		meeting.participantLimit = participantLimit;
+		meeting.rule = rule;
+		meeting.joinQuestion = joinQuestion;
+		meeting.schedule = schedule;
+		meeting.level = level;
+		meeting.minimumAge = minimumAge;
+		meeting.maximumAge = maximumAge;
+		meeting.genderRatio = genderRatio;
+		meeting.hasMembershipFee = hasMembershipFee;
+		meeting.membershipFee = membershipFee;
+		meeting.hobby = hobby;
+		meeting.setHost(host);
+		meeting.setPlace(place);
+
+		return meeting;
+	}
+
 	/*
 	 * 연관관계 설정 메서드
 	 */

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -41,9 +41,11 @@ public class Meeting {
 	@Column(name = "participant_limit")
 	private int participantLimit;
 
+	@Lob
 	@Column(name = "title")
 	private String title;
 
+	@Lob
 	@Column(name = "description")
 	private String description;
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -150,6 +150,39 @@ public class Meeting {
 		return meeting;
 	}
 
+	/**
+	 * 수정 메서드
+	 */
+	public void updateMeeting(Meeting meeting) {
+		this.title = meeting.title;
+		this.description = meeting.description;
+		this.category = meeting.category;
+		this.participantsNumber = meeting.participantsNumber;
+		this.participantLimit = meeting.participantLimit;
+		this.rule = meeting.rule;
+		this.joinQuestion = meeting.joinQuestion;
+		this.schedule = meeting.schedule;
+		this.level = meeting.level;
+		this.minimumAge = meeting.minimumAge;
+		this.maximumAge = meeting.maximumAge;
+		this.genderRatio = meeting.genderRatio;
+		this.hasMembershipFee = meeting.hasMembershipFee;
+		this.membershipFee = meeting.membershipFee;
+		this.hobby = meeting.hobby;
+		this.setMeetingPlace(meeting.getMeetingPlace());
+	}
+
+	/**
+	 * 비즈니스 로직
+	 */
+	public boolean isHost(User user) {
+		return this.host.equals(user);
+	}
+
+	public void changeProgress(Progress progress) {
+		this.progress = progress;
+	}
+
 	/*
 	 * 연관관계 설정 메서드
 	 */

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -24,9 +24,11 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Meeting {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -106,7 +106,7 @@ public class Meeting {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "place_id")
-	private Place place;
+	private MeetingPlace meetingPlace;
 
 	/**
 	 * 생성 메서드
@@ -115,7 +115,6 @@ public class Meeting {
 		String title,
 		String description,
 		Category category,
-		int participantsNumber,
 		int participantLimit,
 		String rule,
 		String joinQuestion,
@@ -127,19 +126,20 @@ public class Meeting {
 		boolean hasMembershipFee,
 		int membershipFee,
 		String hobby,
-		User host,
-		Place place
+		User user,
+		MeetingPlace meetingPlace
 	) {
 		Meeting meeting = new Meeting();
 
 		meeting.title = title;
 		meeting.description = description;
 		meeting.category = category;
-		meeting.participantsNumber = participantsNumber;
+		meeting.participantsNumber = 1;
 		meeting.participantLimit = participantLimit;
 		meeting.rule = rule;
 		meeting.joinQuestion = joinQuestion;
 		meeting.schedule = schedule;
+		meeting.progress = Progress.ONGOING;
 		meeting.level = level;
 		meeting.minimumAge = minimumAge;
 		meeting.maximumAge = maximumAge;
@@ -147,8 +147,8 @@ public class Meeting {
 		meeting.hasMembershipFee = hasMembershipFee;
 		meeting.membershipFee = membershipFee;
 		meeting.hobby = hobby;
-		meeting.setHost(host);
-		meeting.setPlace(place);
+		meeting.setHost(user);
+		meeting.setMeetingPlace(meetingPlace);
 
 		return meeting;
 	}
@@ -189,13 +189,13 @@ public class Meeting {
 	/*
 	 * 연관관계 설정 메서드
 	 */
-	private void setHost(User host) {
-		this.host = host;
-		host.getMeetings().add(this);
+	private void setHost(User user) {
+		this.host = user;
+		user.getRunningMeetings().add(this);
 	}
 
-	private void setPlace(Place place) {
-		this.place = place;
-		place.getMeetings().add(this);
+	private void setMeetingPlace(MeetingPlace meetingPlace) {
+		this.meetingPlace = meetingPlace;
+		meetingPlace.getMeetings().add(this);
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -86,7 +86,8 @@ public class Meeting {
 	@OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
 	private List<MeetingLike> likes = new ArrayList<>();
 
-	// User 엔티티를 구현하지 않았으므로 임시 주석 처리
-	// @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-	// private User author;
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@JoinColumn(name = "user_id")
+	private User host;
+
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -21,7 +21,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -94,8 +93,8 @@ public class Meeting {
 	@OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
 	private List<MeetingLike> likes = new ArrayList<>();
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-	@JoinColumn(name = "user_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "host_id")
 	private User host;
 
 	@OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -63,11 +63,9 @@ public class Meeting {
 	@Column(name = "maximum_age")
 	private int maximumAge;
 
-	@Column(name = "male_ratio")
-	private int maleRatio;
-
-	@Column(name = "femail_ratio")
-	private int femaleRatio;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "gender_ratio")
+	private GenderRatio genderRatio;
 
 	@Column(name = "has_membership_fee")
 	private boolean hasMembershipFee;
@@ -78,9 +76,6 @@ public class Meeting {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "category")
 	private Category category;
-
-	@Column(name = "gender_condition")
-	private String genderCondition;
 
 	@Column(name = "hobby")
 	private String hobby;

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -34,58 +34,62 @@ public class Meeting {
 	@Column(name = "meeting_id")
 	private Long id;
 
-	@Column(name = "participants_number")
-	private int participantsNumber;
-
-	@Column(name = "participant_limit")
-	private int participantLimit;
-
 	@Lob
-	@Column(name = "title")
+	@Column(name = "title", nullable = false)
 	private String title;
 
 	@Lob
-	@Column(name = "description")
+	@Column(name = "description", nullable = false)
 	private String description;
 
-	@Column(name = "view", columnDefinition = "integer default 0", nullable = false)
-	private int view;
-
-	@Column(name = "rule")
+	@Column(name = "rule", nullable = false)
 	private String rule;
 
-	@Column(name = "join_question")
+	@Column(name = "join_question", nullable = false)
 	private String joinQuestion;
 
-	@Column(name = "schedule")
+	@Column(name = "schedule", nullable = false)
 	private LocalDateTime schedule;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "level")
+	@Column(name="progress", nullable = false)
+	private Progress progress;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "level", nullable = false)
 	private Level level;
 
-	@Column(name = "minimum_age")
+	@Column(name = "hobby", nullable = false)
+	private String hobby;
+
+	@Column(name = "participants_number", columnDefinition = "integer default 0", nullable = false)
+	private int participantsNumber;
+
+	@Column(name = "participant_limit", nullable = false)
+	private int participantLimit;
+
+	@Column(name = "minimum_age", nullable = false)
 	private int minimumAge;
 
-	@Column(name = "maximum_age")
+	@Column(name = "maximum_age", nullable = false)
 	private int maximumAge;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "gender_ratio")
+	@Column(name = "gender_ratio", nullable = false)
 	private GenderRatio genderRatio;
 
-	@Column(name = "has_membership_fee")
+	@Column(name = "has_membership_fee", nullable = false)
 	private boolean hasMembershipFee;
 
-	@Column(name = "membership_fee")
+	@Column(name = "membership_fee", nullable = false)
 	private int membershipFee;
 
 	@Enumerated(EnumType.STRING)
-	@Column(name = "category")
+	@Column(name = "category", nullable = false)
 	private Category category;
 
-	@Column(name = "hobby")
-	private String hobby;
+	@Column(name = "view", columnDefinition = "integer default 0", nullable = false)
+	private int view;
 
 	@OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
 	private List<Image> images = new ArrayList<>();

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -104,4 +104,17 @@ public class Meeting {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "place_id")
 	private Place place;
+
+	/*
+	 * 연관관계 설정 메서드
+	 */
+	private void setHost(User host) {
+		this.host = host;
+		host.getMeetings().add(this);
+	}
+
+	private void setPlace(Place place) {
+		this.place = place;
+		place.getMeetings().add(this);
+	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -47,9 +47,6 @@ public class Meeting {
 	@Column(name = "join_question")
 	private String joinQuestion;
 
-	@Column(name = "location")
-	private String location;
-
 	@Column(name = "schedule")
 	private LocalDateTime schedule;
 
@@ -90,4 +87,7 @@ public class Meeting {
 	@JoinColumn(name = "user_id")
 	private User host;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "place_id")
+	private Place place;
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingPlace.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingPlace.java
@@ -17,10 +17,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Place {
+public class MeetingPlace {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "place_id")
+	@Column(name = "meeting_place_id")
 	private Long id;
 
 	@Column(name = "name")
@@ -30,7 +30,7 @@ public class Place {
 	private String placeUrl;
 
 	@Column(name = "map_id")
-	private Long mapId;
+	private Long kakaoMapId;
 
 	@Column(name = "latitude")
 	private Double latitude;
@@ -38,27 +38,27 @@ public class Place {
 	@Column(name = "longitude")
 	private Double longitude;
 
-	@OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "meetingPlace", cascade = CascadeType.ALL)
 	private List<Meeting> meetings = new ArrayList<>();
 
 	/**
 	 * 생성 메서드
 	 */
-	public static Place createPlace(
+	public static MeetingPlace createMeetingPlace(
 		String name,
 		String placeUrl,
 		Long mapId,
 		Double latitude,
 		Double longitude
 	) {
-		Place place = new Place();
+		MeetingPlace meetingPlace = new MeetingPlace();
 
-		place.name = name;
-		place.placeUrl = placeUrl;
-		place.mapId = mapId;
-		place.latitude = latitude;
-		place.longitude = longitude;
+		meetingPlace.name = name;
+		meetingPlace.placeUrl = placeUrl;
+		meetingPlace.kakaoMapId = mapId;
+		meetingPlace.latitude = latitude;
+		meetingPlace.longitude = longitude;
 
-		return place;
+		return meetingPlace;
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingUser.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingUser.java
@@ -1,0 +1,42 @@
+package com.goorm.insideout.meeting.domain;
+
+import com.goorm.insideout.user.domain.User;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class MeetingUser {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "meeting_user_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "approval_status")
+	private ApprovalStatus approvalStatus;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "role")
+	private Role role;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meeting_id")
+	private Meeting meeting;
+
+	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@JoinColumn(name = "user_id")
+	private User user;
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingUser.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingUser.java
@@ -2,7 +2,6 @@ package com.goorm.insideout.meeting.domain;
 
 import com.goorm.insideout.user.domain.User;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.Getter;
 
 @Entity
@@ -36,7 +34,7 @@ public class MeetingUser {
 	@JoinColumn(name = "meeting_id")
 	private Meeting meeting;
 
-	@OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Place.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Place.java
@@ -1,0 +1,64 @@
+package com.goorm.insideout.meeting.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "place_id")
+	private Long id;
+
+	@Column(name = "name")
+	private String name;
+
+	@Column(name = "place_url")
+	private String placeUrl;
+
+	@Column(name = "map_id")
+	private Long mapId;
+
+	@Column(name = "latitude")
+	private Double latitude;
+
+	@Column(name = "longitude")
+	private Double longitude;
+
+	@OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
+	private List<Meeting> meetings = new ArrayList<>();
+
+	/**
+	 * 생성 메서드
+	 */
+	public static Place createPlace(
+		String name,
+		String placeUrl,
+		Long mapId,
+		Double latitude,
+		Double longitude
+	) {
+		Place place = new Place();
+
+		place.name = name;
+		place.placeUrl = placeUrl;
+		place.mapId = mapId;
+		place.latitude = latitude;
+		place.longitude = longitude;
+
+		return place;
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Progress.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Progress.java
@@ -1,0 +1,6 @@
+package com.goorm.insideout.meeting.domain;
+
+public enum Progress {
+	ONGOING,
+	ENDED
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Role.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Role.java
@@ -1,0 +1,14 @@
+package com.goorm.insideout.meeting.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Role {
+
+	HOST("호스트"),
+	MEMBER("멤버");
+
+	private final String name;
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/request/MeetingCreateRequest.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/request/MeetingCreateRequest.java
@@ -1,0 +1,94 @@
+package com.goorm.insideout.meeting.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.goorm.insideout.meeting.domain.Category;
+import com.goorm.insideout.meeting.domain.GenderRatio;
+import com.goorm.insideout.meeting.domain.Level;
+import com.goorm.insideout.meeting.domain.Meeting;
+import com.goorm.insideout.meeting.domain.MeetingPlace;
+import com.goorm.insideout.user.domain.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class MeetingCreateRequest {
+	private String title;
+
+	private String description;
+
+	private String category;
+
+	private MeetingPlaceRequest meetingPlace;
+
+	private int participantLimit;
+
+	private String rule;
+
+	private String joinQuestion;
+
+	private LocalDateTime schedule;
+
+	private String level;
+
+	private int minimumAge;
+
+	private int maximumAge;
+
+	private int maleRatio;
+
+	private int femaleRatio;
+
+	private boolean hasMembershipFee;
+
+	private int membershipFee;
+
+	private String hobby;
+
+	public Meeting toEntity(User host, MeetingPlace meetingPlace) {
+		return Meeting.createMeeting(
+			title,
+			description,
+			Category.valueOf(category),
+			participantLimit,
+			rule,
+			joinQuestion,
+			schedule,
+			Level.valueOf(level),
+			minimumAge,
+			maximumAge,
+			GenderRatio.valueOf(maleRatio, femaleRatio),
+			hasMembershipFee,
+			membershipFee,
+			hobby,
+			host,
+			meetingPlace
+		);
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class MeetingPlaceRequest {
+		private String name;
+
+		private String placeUrl;
+
+		private Long kakaoMapId;
+
+		private Double latitude;
+
+		private Double longitude;
+
+		public MeetingPlace toEntity() {
+			return MeetingPlace.createMeetingPlace(
+				name,
+				placeUrl,
+				kakaoMapId,
+				latitude,
+				longitude
+			);
+		}
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/request/MeetingUpdateRequest.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/request/MeetingUpdateRequest.java
@@ -1,0 +1,94 @@
+package com.goorm.insideout.meeting.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.goorm.insideout.meeting.domain.Category;
+import com.goorm.insideout.meeting.domain.GenderRatio;
+import com.goorm.insideout.meeting.domain.Level;
+import com.goorm.insideout.meeting.domain.Meeting;
+import com.goorm.insideout.meeting.domain.MeetingPlace;
+import com.goorm.insideout.user.domain.User;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class MeetingUpdateRequest {
+	private String title;
+
+	private String description;
+
+	private String category;
+
+	private MeetingPlaceRequest meetingPlace;
+
+	private int participantLimit;
+
+	private String rule;
+
+	private String joinQuestion;
+
+	private LocalDateTime schedule;
+
+	private String level;
+
+	private int minimumAge;
+
+	private int maximumAge;
+
+	private int maleRatio;
+
+	private int femaleRatio;
+
+	private boolean hasMembershipFee;
+
+	private int membershipFee;
+
+	private String hobby;
+
+	public Meeting toEntity(User host) {
+		return Meeting.createMeeting(
+			title,
+			description,
+			Category.valueOf(category),
+			participantLimit,
+			rule,
+			joinQuestion,
+			schedule,
+			Level.valueOf(level),
+			minimumAge,
+			maximumAge,
+			GenderRatio.valueOf(maleRatio, femaleRatio),
+			hasMembershipFee,
+			membershipFee,
+			hobby,
+			host,
+			meetingPlace.toEntity()
+		);
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	private static class MeetingPlaceRequest {
+		private String name;
+
+		private String placeUrl;
+
+		private Long kakaoMapId;
+
+		private Double latitude;
+
+		private Double longitude;
+
+		private MeetingPlace toEntity() {
+			return MeetingPlace.createMeetingPlace(
+				name,
+				placeUrl,
+				kakaoMapId,
+				latitude,
+				longitude
+			);
+		}
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/response/MeetingResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/response/MeetingResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.goorm.insideout.image.dto.response.ImageResponse;
 import com.goorm.insideout.meeting.domain.Meeting;
+import com.goorm.insideout.meeting.domain.MeetingPlace;
 import com.querydsl.core.annotations.QueryProjection;
 
 import lombok.Getter;
@@ -24,14 +25,14 @@ public class MeetingResponse {
 	private int like;
 	private boolean hasMembershipFee;
 	private int membershipFee;
+	private String progress;
 	private String level;
 	private String hobby;
 	private String category;
-	private String location;
+	private MeetingPlaceResponse place;
 	private LocalDateTime schedule;
 	private int participantsNumber;
 	private int participantLimit;
-	private String genderCondition;
 	private int maleRatio;
 	private int femaleRatio;
 	private int minimumAge;
@@ -53,21 +54,43 @@ public class MeetingResponse {
 		this.like = meeting.getLikes().size();
 		this.hasMembershipFee = meeting.isHasMembershipFee();
 		this.membershipFee = meeting.getMembershipFee();
-		this.level = meeting.getLevel().getName();
+		this.progress = meeting.getProgress().name();
+		this.level = meeting.getLevel().name();
 		this.hobby = meeting.getHobby();
-		this.category = meeting.getCategory().getName();
-		this.location = meeting.getLocation();
+		this.category = meeting.getCategory().name();
+		this.place = new MeetingPlaceResponse().toDto(meeting.getMeetingPlace());
 		this.schedule = meeting.getSchedule();
 		this.participantsNumber = meeting.getParticipantsNumber();
 		this.participantLimit = meeting.getParticipantLimit();
-		this.genderCondition = meeting.getGenderCondition();
-		this.maleRatio = meeting.getMaleRatio();
-		this.femaleRatio = meeting.getFemaleRatio();
+		this.maleRatio = meeting.getGenderRatio().getMaleRatio();
+		this.femaleRatio = meeting.getGenderRatio().getFemaleRatio();
 		this.minimumAge = meeting.getMinimumAge();
 		this.maximumAge = meeting.getMaximumAge();
 	}
 
-	public MeetingResponse from(Meeting meeting) {
+	public static MeetingResponse from(Meeting meeting) {
 		return new MeetingResponse(meeting);
+	}
+
+	public static class MeetingPlaceResponse {
+		private String name;
+
+		private String placeUrl;
+
+		private Long kakaoMapId;
+
+		private Double latitude;
+
+		private Double longitude;
+
+		private MeetingPlaceResponse toDto(MeetingPlace meetingPlace) {
+			this.name = meetingPlace.getName();
+			this.placeUrl = meetingPlace.getPlaceUrl();
+			this.kakaoMapId = meetingPlace.getKakaoMapId();
+			this.latitude = meetingPlace.getLatitude();
+			this.longitude = meetingPlace.getLongitude();
+
+			return this;
+		}
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/repository/MeetingRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/repository/MeetingRepository.java
@@ -1,9 +1,16 @@
 package com.goorm.insideout.meeting.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.goorm.insideout.meeting.domain.Meeting;
+import com.goorm.insideout.meeting.domain.Progress;
 import com.goorm.insideout.meeting.repository.custom.MeetingQueryDslRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long>, MeetingQueryDslRepository {
+	// 내가 호스트인 모임 목록 찾기
+	@Query("select m from Meeting m where m.host.id = ?1 and m.progress = ?2")
+	Page<Meeting> findRunningMeetings(Long id, Progress progress, Pageable pageable);
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/repository/MeetingUserRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/repository/MeetingUserRepository.java
@@ -1,0 +1,23 @@
+package com.goorm.insideout.meeting.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.goorm.insideout.meeting.domain.ApprovalStatus;
+import com.goorm.insideout.meeting.domain.MeetingUser;
+import com.goorm.insideout.meeting.domain.Progress;
+
+public interface MeetingUserRepository extends JpaRepository<MeetingUser, Long> {
+	// 나의 모임 참여 목록 찾기 -> 이후 Meeting 객체로 변경
+	@Query("select m from MeetingUser m where m.user.id = ?1 and m.approvalStatus = ?2 and m.meeting.progress = ?3")
+	Page<MeetingUser> findOngoingMeetingsByProgress(Long id, ApprovalStatus approvalStatus,
+		Progress progress, Pageable pageable);
+
+	// 참여중인 모임 중, 이미 종료된 모임 참여 목록 찾기 -> 이후 Meeting 객체로 변경
+	@Query("select m from MeetingUser m where m.user.id = ?1 and m.approvalStatus = ?2 and m.meeting.progress = ?3")
+	Page<MeetingUser> findEndedMeetings(Long id, ApprovalStatus approvalStatus, Progress progress, Pageable pageable);
+
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/repository/PlaceRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/repository/PlaceRepository.java
@@ -1,0 +1,13 @@
+package com.goorm.insideout.meeting.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.goorm.insideout.meeting.domain.MeetingPlace;
+
+public interface PlaceRepository extends JpaRepository<MeetingPlace, Long> {
+	@Query("select p from MeetingPlace p where p.name = ?1 and p.latitude = ?2 and p.longitude = ?3")
+	Optional<MeetingPlace> findPlaceByNameAndLocation(String name, Double latitude, Double longitude);
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goorm.insideout.auth.dto.CustomUserDetails;
 import com.goorm.insideout.global.exception.ErrorCode;
 import com.goorm.insideout.global.exception.ModongException;
 import com.goorm.insideout.meeting.domain.ApprovalStatus;
@@ -21,6 +22,7 @@ import com.goorm.insideout.meeting.repository.MeetingRepository;
 import com.goorm.insideout.meeting.repository.MeetingUserRepository;
 import com.goorm.insideout.meeting.repository.PlaceRepository;
 import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,11 +33,15 @@ public class MeetingService {
 	private final MeetingRepository meetingRepository;
 	private final MeetingUserRepository meetingUserRepository;
 	private final PlaceRepository placeRepository;
+	private final UserRepository userRepository;
 
 	@Transactional
-	public Long save(MeetingCreateRequest request, User user) {
-		MeetingPlace meetingPlace = findOrCreatePlace(request.getMeetingPlace());
+	public Long save(MeetingCreateRequest request, CustomUserDetails customUserDetails) {
+		User user = userRepository.findById(customUserDetails.getUser().getId())
+			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
+		userRepository.save(user);
 
+		MeetingPlace meetingPlace = findOrCreatePlace(request.getMeetingPlace());
 		Meeting meeting = request.toEntity(user, meetingPlace);
 		meetingRepository.save(meeting);
 
@@ -59,52 +65,69 @@ public class MeetingService {
 		return meetingRepository.findAllBySortType(condition, pageable);
 	}
 
-	public Page<MeetingResponse> findPendingMeetings(Long userId, Pageable pageable) {
+	public Page<MeetingResponse> findPendingMeetings(CustomUserDetails customUserDetails, Pageable pageable) {
+		Long userId = customUserDetails.getUser().getId();
+
 		return meetingUserRepository.findOngoingMeetingsByProgress(userId, ApprovalStatus.PENDING, Progress.ONGOING, pageable)
 			.map(meetingUser -> MeetingResponse.from(meetingUser.getMeeting()));
 	}
 
-	public Page<MeetingResponse> findParticipatingMeetings(Long userId, Pageable pageable) {
+	public Page<MeetingResponse> findParticipatingMeetings(CustomUserDetails customUserDetails, Pageable pageable) {
+		Long userId = customUserDetails.getUser().getId();
+
 		return meetingUserRepository.findOngoingMeetingsByProgress(userId, ApprovalStatus.APPROVED, Progress.ONGOING, pageable)
 			.map(meetingUser -> MeetingResponse.from(meetingUser.getMeeting()));
 	}
 
-	public Page<MeetingResponse> findRunningMeetings(Long hostId, Pageable pageable) {
+	public Page<MeetingResponse> findRunningMeetings(CustomUserDetails customUserDetails, Pageable pageable) {
+		Long hostId = customUserDetails.getUser().getId();
+
 		return meetingRepository.findRunningMeetings(hostId, Progress.ONGOING, pageable)
 			.map(MeetingResponse::from);
 	}
 
-	public Page<MeetingResponse> findEndedMeetings(Long userId, Pageable pageable) {
+	public Page<MeetingResponse> findEndedMeetings(CustomUserDetails customUserDetails, Pageable pageable) {
+		Long userId = customUserDetails.getUser().getId();
+
 		return meetingUserRepository.findEndedMeetings(userId, ApprovalStatus.APPROVED, Progress.ENDED, pageable)
 			.map(meetingUser -> MeetingResponse.from(meetingUser.getMeeting()));
 	}
 
 	@Transactional
-	public void updateById(User user, Long meetingId, MeetingUpdateRequest request) {
+	public void updateById(CustomUserDetails customUserDetails, Long meetingId, MeetingUpdateRequest request) {
 		// 수정할 모임 조회 후, 수정을 요청한 유저가 호스트인지 검증
 		Meeting meeting = meetingRepository.findById(meetingId)
 			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_NOT_FOUND));
+
+		User user = userRepository.findById(customUserDetails.getUser().getId())
+			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
 		validateIsHost(user, meeting);
 
 		meeting.updateMeeting(request.toEntity(user));
 	}
 
 	@Transactional
-	public void deleteById(User user, Long meetingId) {
+	public void deleteById(CustomUserDetails customUserDetails, Long meetingId) {
 		// 삭제할 모임 조회 후, 삭제를 요청한 유저가 호스트인지 검증
 		Meeting meeting = meetingRepository.findById(meetingId)
 			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_NOT_FOUND));
+
+		User user = userRepository.findById(customUserDetails.getUser().getId())
+			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
 		validateIsHost(user, meeting);
 
 		meetingRepository.deleteById(meetingId);
 	}
 
 	@Transactional
-	public void endMeeting(User user, Long meetingId) {
+	public void endMeeting(CustomUserDetails customUserDetails, Long meetingId) {
 		Meeting meeting = meetingRepository.findById(meetingId)
 			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_NOT_FOUND));
 
+		User user = userRepository.findById(customUserDetails.getUser().getId())
+			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
 		validateIsHost(user, meeting);
+
 		meeting.changeProgress(Progress.ENDED);
 	}
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
@@ -1,27 +1,126 @@
 package com.goorm.insideout.meeting.service;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.exception.ModongException;
+import com.goorm.insideout.meeting.domain.ApprovalStatus;
+import com.goorm.insideout.meeting.domain.Meeting;
+import com.goorm.insideout.meeting.domain.MeetingPlace;
+import com.goorm.insideout.meeting.domain.Progress;
+import com.goorm.insideout.meeting.dto.request.MeetingCreateRequest;
 import com.goorm.insideout.meeting.dto.request.MeetingSearchRequest;
+import com.goorm.insideout.meeting.dto.request.MeetingUpdateRequest;
 import com.goorm.insideout.meeting.dto.response.MeetingResponse;
 import com.goorm.insideout.meeting.repository.MeetingRepository;
+import com.goorm.insideout.meeting.repository.MeetingUserRepository;
+import com.goorm.insideout.meeting.repository.PlaceRepository;
+import com.goorm.insideout.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MeetingService {
 	private final MeetingRepository meetingRepository;
+	private final MeetingUserRepository meetingUserRepository;
+	private final PlaceRepository placeRepository;
 
-	public Page<MeetingResponse> findAllByCondition(MeetingSearchRequest condition, Pageable pageable) {
+	@Transactional
+	public Long save(MeetingCreateRequest request, User user) {
+		MeetingPlace meetingPlace = findOrCreatePlace(request.getMeetingPlace());
+
+		Meeting meeting = request.toEntity(user, meetingPlace);
+		meetingRepository.save(meeting);
+
+		return meeting.getId();
+	}
+
+	public MeetingResponse findById(Long id) {
+		Meeting meeting = meetingRepository.findById(id)
+			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_NOT_FOUND));
+
+		return new MeetingResponse(meeting);
+	}
+
+	// 검색
+	public Page<MeetingResponse> findByCondition(MeetingSearchRequest condition, Pageable pageable) {
 		return meetingRepository.findAllByCondition(condition, pageable);
 	}
 
-	public Page<MeetingResponse> findAllBySortType(MeetingSearchRequest condition, Pageable pageable) {
+	// 검색 및 정렬
+	public Page<MeetingResponse> findBySortType(MeetingSearchRequest condition, Pageable pageable) {
 		return meetingRepository.findAllBySortType(condition, pageable);
+	}
+
+	public Page<MeetingResponse> findPendingMeetings(Long userId, Pageable pageable) {
+		return meetingUserRepository.findOngoingMeetingsByProgress(userId, ApprovalStatus.PENDING, Progress.ONGOING, pageable)
+			.map(meetingUser -> MeetingResponse.from(meetingUser.getMeeting()));
+	}
+
+	public Page<MeetingResponse> findParticipatingMeetings(Long userId, Pageable pageable) {
+		return meetingUserRepository.findOngoingMeetingsByProgress(userId, ApprovalStatus.APPROVED, Progress.ONGOING, pageable)
+			.map(meetingUser -> MeetingResponse.from(meetingUser.getMeeting()));
+	}
+
+	public Page<MeetingResponse> findRunningMeetings(Long hostId, Pageable pageable) {
+		return meetingRepository.findRunningMeetings(hostId, Progress.ONGOING, pageable)
+			.map(MeetingResponse::from);
+	}
+
+	public Page<MeetingResponse> findEndedMeetings(Long userId, Pageable pageable) {
+		return meetingUserRepository.findEndedMeetings(userId, ApprovalStatus.APPROVED, Progress.ENDED, pageable)
+			.map(meetingUser -> MeetingResponse.from(meetingUser.getMeeting()));
+	}
+
+	@Transactional
+	public void updateById(User user, Long meetingId, MeetingUpdateRequest request) {
+		// 수정할 모임 조회 후, 수정을 요청한 유저가 호스트인지 검증
+		Meeting meeting = meetingRepository.findById(meetingId)
+			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_NOT_FOUND));
+		validateIsHost(user, meeting);
+
+		meeting.updateMeeting(request.toEntity(user));
+	}
+
+	@Transactional
+	public void deleteById(User user, Long meetingId) {
+		// 삭제할 모임 조회 후, 삭제를 요청한 유저가 호스트인지 검증
+		Meeting meeting = meetingRepository.findById(meetingId)
+			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_NOT_FOUND));
+		validateIsHost(user, meeting);
+
+		meetingRepository.deleteById(meetingId);
+	}
+
+	@Transactional
+	public void endMeeting(User user, Long meetingId) {
+		Meeting meeting = meetingRepository.findById(meetingId)
+			.orElseThrow(() -> ModongException.from(ErrorCode.MEETING_NOT_FOUND));
+
+		validateIsHost(user, meeting);
+		meeting.changeProgress(Progress.ENDED);
+	}
+
+	private void validateIsHost(User user, Meeting meeting) {
+		if (!meeting.isHost(user)) {
+			throw ModongException.from(ErrorCode.MEETING_NOT_HOST);
+		}
+	}
+
+	private MeetingPlace findOrCreatePlace(MeetingCreateRequest.MeetingPlaceRequest request) {
+		Optional<MeetingPlace> meetingPlace = placeRepository.findPlaceByNameAndLocation(
+			request.getName(),
+			request.getLatitude(),
+			request.getLongitude()
+		);
+
+		return meetingPlace.orElseGet(() -> placeRepository.save(request.toEntity()));
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/search/controller/SearchController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/search/controller/SearchController.java
@@ -30,8 +30,8 @@ public class SearchController {
 		MeetingSearchRequest condition = new MeetingSearchRequest(query, category, sortType);
 		PageRequest pageRequest = PageRequest.of(page - 1, 20);
 
-		Page<MeetingResponse> searchResult = meetingService.findAllBySortType(condition, pageRequest);
+		Page<MeetingResponse> searchResult = meetingService.findBySortType(condition, pageRequest);
 
-		return new ApiResponse<>(searchResult.getContent(), searchResult.getPageable());
+		return new ApiResponse<>(searchResult);
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
@@ -1,10 +1,17 @@
 package com.goorm.insideout.user.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.goorm.insideout.meeting.domain.Meeting;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,5 +40,8 @@ public class User {
 
 	@Column(nullable = false)
 	private String name;
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+	private List<Meeting> meetings = new ArrayList<>();
 
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
@@ -16,6 +16,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,6 +28,7 @@ import lombok.Setter;
 @Setter
 @Getter
 @Table(name = "USERS")
+@EqualsAndHashCode(callSuper = false, of = {"id"})
 public class User {
 
 	@Id

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.goorm.insideout.meeting.domain.Meeting;
+import com.goorm.insideout.meeting.domain.MeetingUser;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -41,7 +42,10 @@ public class User {
 	@Column(nullable = false)
 	private String name;
 
+	@OneToMany(mappedBy = "host", cascade = CascadeType.ALL)
+	private List<Meeting> runningMeetings = new ArrayList<>();
+
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-	private List<Meeting> meetings = new ArrayList<>();
+	private List<MeetingUser> meetingUsers = new ArrayList<>();
 
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> ex) #35 

### 📝 작업 내용

✅ 기능 구현
- 모임 단건 조회 및 목록 조회 기능을 구현하였습니다.
  - 모임 단건 조회
  - 나의 승인대기 모임 목록 조회
  - 나의 참여중인 모임 목록 조회
  - 나의 운영중인 모임 목록 조회
  - 나의 종료된 모임 목록 조회
- 모임 정보 수정, 모임 종료, 모임 삭제 등의 기능을 구현하였습니다.

- 기존 모임 엔티티와 관련된 `MeetingPlace`, `MeetingUser` 등의 엔티티를 비롯하여 여러가지 연관관계를 추가하였습니다.

✅ 특이 사항
- 기존에 develop에 있던 로그인 + 시큐리티 설정과 함께 테스트를 진행해봤는데 뭔가 인증 인가가 제대로 되지 않는 것 같아 테스트를 깊게는 못했습니다..
  - 분명 `/api/meetings/1`로 요청했는데 뜬금없이 `/api/api/meetings/1`로 요청되는 문제가 생겼습니다.
  - 다른 회원가입 or 로그인 기능은 포스트맨에 API 응답이 뜨는데, 이상하게 저는 안 뜨고 403 에러가 뜹니다.. 근데 에러가 뜬 거 치고는 DB에 데이터는 잘 들어갑니다.
- develop 브랜치랑 병합해서 이미지 업로드 기능과 함께 테스트 좀 더 진행해보고, 안되면 회의 때 들고오겠습니다!

### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)

워낙 변경사항이 많아서 아마 보기 힘드실 것 같습니다 ㅋㅋㅋ `MeetingController.java` 에서 API 잘 구현됐는지만 봐주시면 될 것 같아요