### PR TITLE
Feat/채팅방 기본 curd 구현#40

### DIFF
--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/controller/ChatController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/controller/ChatController.java
@@ -1,13 +1,18 @@
 package com.goorm.insideout.chat.controller;
 
 import java.security.Principal;
+import java.util.List;
 
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goorm.insideout.auth.dto.CustomUserDetails;
 import com.goorm.insideout.chat.domain.Chat;
 import com.goorm.insideout.chat.dto.request.ChatRequestDTO;
 import com.goorm.insideout.chat.dto.response.ChatResponseDTO;
@@ -23,17 +28,27 @@ public class ChatController {
 	private final ChatService chatService;
 	private final SimpMessageSendingOperations messagingTemplate;
 
+	// 메세지 전송
 	@MessageMapping("/chatRoom/{chatRoomId}")
 	public ApiResponse messageHandler(@DestinationVariable("chatRoomId") Long roomId,
 		@RequestBody ChatRequestDTO chatRequestDTO, Principal principal) {
-
-		Chat chat = chatService.createChat(roomId, chatRequestDTO, principal);
+		String email = principal.getName();
+		Chat chat = chatService.createChat(roomId, chatRequestDTO, email);
 		ChatResponseDTO chatResponseDTO = ChatResponseDTO.builder()
 			.content(chat.getContent())
 			.sender(chat.getUser().getName())
 			.sendTime(chat.getSendTime()).build();
 		messagingTemplate.convertAndSend("/sub/chatRoom/" + roomId, chatResponseDTO);
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
-
 	}
+
+	// 메세지 로그 가져오기
+	@GetMapping("/api/chatroom/{chatRoomId}/logs")
+	public ApiResponse<List<ChatResponseDTO>> getChatLogs(@PathVariable Long chatRoomId,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		Long userId = customUserDetails.getUser().getId();
+		List<ChatResponseDTO> chatLogs = chatService.getUnreadMessages(userId, chatRoomId);
+		return new ApiResponse<List<ChatResponseDTO>>(chatLogs);
+	}
+
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/request/ChatRequestDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/request/ChatRequestDTO.java
@@ -1,10 +1,12 @@
 package com.goorm.insideout.chat.dto.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class ChatRequestDTO {
 	private String content;
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/response/ChatResponseDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/dto/response/ChatResponseDTO.java
@@ -1,6 +1,7 @@
 package com.goorm.insideout.chat.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -14,4 +15,20 @@ public class ChatResponseDTO {
 	private LocalDateTime sendTime;
 	private String sender;
 
+	// Getter, Setter, and Builder methods
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ChatResponseDTO that = (ChatResponseDTO) o;
+		return Objects.equals(content, that.content) &&
+			Objects.equals(sendTime, that.sendTime) &&
+			Objects.equals(sender, that.sender);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(content, sendTime, sender);
+	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/repository/ChatRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/repository/ChatRepository.java
@@ -1,9 +1,25 @@
 package com.goorm.insideout.chat.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goorm.insideout.chat.domain.Chat;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+	// 채팅방의 전체 메시지 개수를 세는 메서드
+	long countByChatRoomId(Long chatRoomId);
 
+	// 특정 시간 이후의 메시지 개수를 세는 메서드
+	long countByChatRoomIdAndSendTimeAfter(Long chatRoomId, LocalDateTime lastVisitedTime);
+
+	List<Chat> findAllByChatRoomId(Long chatRoomId);
+
+	// 특정 시간 이후의 읽지 않은 메시지 목록을 조회하는 메서드
+	@Query("SELECT c FROM Chat c WHERE c.chatRoom.id = :chatRoomId AND c.sendTime > :lastVisitedTime")
+	List<Chat> findAllUnreadMessages(@Param("chatRoomId") Long chatRoomId, @Param("lastVisitedTime") LocalDateTime lastVisitedTime);
 }
+

--- a/Inside-Out/src/main/java/com/goorm/insideout/chat/service/ChatService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chat/service/ChatService.java
@@ -1,13 +1,15 @@
 package com.goorm.insideout.chat.service;
 
-import java.security.Principal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.goorm.insideout.chat.domain.Chat;
 import com.goorm.insideout.chat.dto.request.ChatRequestDTO;
+import com.goorm.insideout.chat.dto.response.ChatResponseDTO;
 import com.goorm.insideout.chat.repository.ChatRepository;
 import com.goorm.insideout.chatroom.domain.ChatRoom;
 import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
@@ -15,6 +17,7 @@ import com.goorm.insideout.global.exception.ErrorCode;
 import com.goorm.insideout.global.exception.ModongException;
 import com.goorm.insideout.user.domain.User;
 import com.goorm.insideout.user.repository.UserRepository;
+import com.goorm.insideout.userchatroom.repository.UserChatRoomRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,41 +25,63 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ChatService {
 
-	private final ChatRoomRepository chatRoomRepository;
 	private final ChatRepository chatRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final UserChatRoomRepository userChatRoomRepository;
 	private final UserRepository userRepository;
+
+	// 채팅 생성
 	@Transactional
-	public Chat createChat(Long roomId, ChatRequestDTO message, Principal principal) {
-
-		// 채팅을 작성한 작성자 찾기
-		User sender = getSender(principal.getName());
-
-		// 채팅방 찾기
+	public Chat createChat(Long roomId, ChatRequestDTO message, String email) {
 		ChatRoom chatRoom = getChatRoom(roomId);
 
-		// 채팅 엔티티 생성
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> ModongException.from(ErrorCode.CHATROOM_NOT_FOUND));
 
 		Chat chat = Chat.builder()
 			.content(message.getContent())
 			.chatRoom(chatRoom)
-			.user(sender)
+			.user(user)
 			.sendTime(LocalDateTime.now())
 			.build();
+
+		updateChatRoomLastMessage(chatRoom, message.getContent());
 		return chatRepository.save(chat);
-
 	}
 
-	private User getSender(String email) {
-		//해당 이메일로 가입한 유저가 존재하는지 확인
-		return userRepository.findByEmail(email)
-			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
+	// 읽지 않은 메시지 조회
+	@Transactional(readOnly = true)
+	public List<ChatResponseDTO> getUnreadMessages(Long userId, Long chatRoomId) {
+		LocalDateTime lastVisitedTime = userChatRoomRepository.findConfigTime(userId, chatRoomId);
+		List<Chat> chats = (lastVisitedTime == null) ?
+			chatRepository.findAllByChatRoomId(chatRoomId) :
+			chatRepository.findAllUnreadMessages(chatRoomId, lastVisitedTime);
+
+		return chats.stream()
+			.map(this::convertToChatResponseDTO)
+			.collect(Collectors.toList());
 	}
 
+	// 채팅방 가져오기
 	private ChatRoom getChatRoom(Long roomId) {
-		//해당 PK에 맞는 채팅방 검색
 		return chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> ModongException.from(ErrorCode.CHATROOM_NOT_FOUND));
+	}
 
+	// 채팅방 마지막 메시지 업데이트
+	private void updateChatRoomLastMessage(ChatRoom chatRoom, String messageContent) {
+		chatRoom.setLastMessageContent(messageContent);
+		chatRoom.setLastMessageTime(LocalDateTime.now());
+		chatRoomRepository.save(chatRoom);
+	}
+
+	// Chat 엔티티를 ChatResponseDTO로 변환
+	private ChatResponseDTO convertToChatResponseDTO(Chat chat) {
+		return ChatResponseDTO.builder()
+			.content(chat.getContent())
+			.sendTime(chat.getSendTime())
+			.sender(chat.getUser().getName())
+			.build();
 	}
 
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/controller/ChatRoomController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/controller/ChatRoomController.java
@@ -1,0 +1,52 @@
+package com.goorm.insideout.chatroom.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goorm.insideout.auth.dto.CustomUserDetails;
+import com.goorm.insideout.chatroom.dto.response.ChatRoomResponseDTO;
+import com.goorm.insideout.chatroom.service.ChatRoomService;
+import com.goorm.insideout.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+	private final ChatRoomService chatRoomService;
+
+	// 한 유저가 속한 전체 채팅방 가져오기
+	@GetMapping("/chatrooms")
+	public ApiResponse<List<ChatRoomResponseDTO>> getChatRoomsByUserId(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		Long userId = customUserDetails.getUser().getId();
+		// 사용자 정보를 기반으로 로직 수행
+		List<ChatRoomResponseDTO> chatRooms = chatRoomService.getChatRoomsByUserId(userId);
+		return new ApiResponse<List<ChatRoomResponseDTO>>(chatRooms);
+	}
+
+	// 한 유저가 속한 동아리 채팅방 가져오기
+	@GetMapping("/chatrooms/club")
+	public ApiResponse<List<ChatRoomResponseDTO>> getClubRoomsByUserId(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		Long userId = customUserDetails.getUser().getId();
+		List<ChatRoomResponseDTO> chatRooms = chatRoomService.getClubRoomsByUserId(userId);
+		return new ApiResponse<List<ChatRoomResponseDTO>>(chatRooms);
+	}
+
+	// 한 유저가 속한 모임 채팅방 가져오기
+	@GetMapping("/chatrooms/meeting")
+	public ApiResponse<List<ChatRoomResponseDTO>> getMeetingRoomsByUserId(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		Long userId = customUserDetails.getUser().getId();
+		List<ChatRoomResponseDTO> chatRooms = chatRoomService.getMeetingRoomsByUserId(userId);
+		return new ApiResponse<List<ChatRoomResponseDTO>>(chatRooms);
+	}
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/domain/ChatRoom.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/domain/ChatRoom.java
@@ -1,13 +1,7 @@
 package com.goorm.insideout.chatroom.domain;
 
-import static jakarta.persistence.FetchType.*;
+import java.time.LocalDateTime;
 
-import java.sql.Timestamp;
-import java.util.Set;
-
-import com.goorm.insideout.chat.domain.Chat;
-
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -15,7 +9,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,22 +27,21 @@ public class ChatRoom {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "chat_room_id")
-	private long id;
+	private Long id;
 
 	@Column(name = "title", updatable = false, nullable = false, unique = true)
 	private String title;
-
-	@Column(name = "created_at", nullable = false)
-	private Timestamp createdAt;
 
 	@Column(name = "type", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private ChatRoomType type;
 
 	@Column(name = "associated_id", nullable = false)
-	private long associatedId; // 동아리 또는 모임의 ID
+	private Long associatedId; // 동아리 또는 모임의 ID
 
-	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = LAZY)
-	private Set<Chat> messages;
+	@Column(name = "last_message_content") // 데이터베이스와 매핑됨
+	private String lastMessageContent;
 
+	@Column(name = "last_message_time") // 데이터베이스와 매핑됨
+	private LocalDateTime lastMessageTime;
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/dto/response/ChatRoomResponseDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/dto/response/ChatRoomResponseDTO.java
@@ -1,0 +1,27 @@
+package com.goorm.insideout.chatroom.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.goorm.insideout.chatroom.domain.ChatRoomType;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ChatRoomResponseDTO {
+
+	private String title;
+
+	private ChatRoomType type;
+
+	private String lastMessageContent;
+
+	private LocalDateTime lastMessageTime;
+
+	private Long userCount;
+
+	private Long unreadMessageCnt;
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/repository/ChatRoomRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/repository/ChatRoomRepository.java
@@ -5,7 +5,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.chatroom.domain.ChatRoomType;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-	Optional<ChatRoom> findById(long id);
+	Optional<ChatRoom> findById(Long ChatRoomId);
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/chatroom/service/ChatRoomService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/chatroom/service/ChatRoomService.java
@@ -1,0 +1,110 @@
+package com.goorm.insideout.chatroom.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goorm.insideout.chat.repository.ChatRepository;
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.chatroom.domain.ChatRoomType;
+import com.goorm.insideout.chatroom.dto.response.ChatRoomResponseDTO;
+import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
+import com.goorm.insideout.userchatroom.repository.UserChatRoomRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+	private final UserChatRoomRepository userChatRoomRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatRepository chatRepository;
+
+	// 채팅방 생성
+	@Transactional
+	public ChatRoom createChatRoom(Long associatedId, String title, ChatRoomType type) {
+		ChatRoom chatRoom = ChatRoom.builder()
+			.associatedId(associatedId)
+			.title(title)
+			.type(type)
+			.build();
+		return chatRoomRepository.save(chatRoom);
+	}
+
+	// 채팅방 목록 조회
+	@Transactional(readOnly = true)
+	public List<ChatRoomResponseDTO> getChatRoomsByUserId(Long userId) {
+		return getChatRoomsByUserIdAndType(userId, null);
+	}
+
+	// 클럽 채팅방 조회
+	@Transactional(readOnly = true)
+	public List<ChatRoomResponseDTO> getClubRoomsByUserId(Long userId) {
+		return getChatRoomsByUserIdAndType(userId, ChatRoomType.CLUB);
+	}
+
+	// 미팅 채팅방 조회
+	@Transactional(readOnly = true)
+	public List<ChatRoomResponseDTO> getMeetingRoomsByUserId(Long userId) {
+		return getChatRoomsByUserIdAndType(userId, ChatRoomType.MEETING);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ChatRoomResponseDTO> getChatRoomsByUserIdAndType(Long userId, ChatRoomType type) {
+		List<Long> chatRoomIds = getChatRoomIdsByUserId(userId);
+
+		Map<Long, Long> userCountByChatRoomId = getUserCountByChatRoomId(chatRoomIds);
+		Map<Long, Long> unreadMessageCountByChatRoomId = getUnreadMessageCountByChatRoomId(userId, chatRoomIds);
+
+		return chatRoomRepository.findAllById(chatRoomIds).stream()
+			.filter(chatRoom -> type == null || type.equals(chatRoom.getType()))
+			.map(chatRoom -> convertToChatRoomResponseDTO(
+				chatRoom,
+				userCountByChatRoomId.getOrDefault(chatRoom.getId(), 0L),
+				unreadMessageCountByChatRoomId.getOrDefault(chatRoom.getId(), 0L)))
+			.collect(Collectors.toList());
+	}
+
+	// 회원이 속한 채팅방 다 가져오기
+	private List<Long> getChatRoomIdsByUserId(Long userId) {
+		return userChatRoomRepository.findByUserId(userId).stream()
+			.map(userChatRoom -> userChatRoom.getChatRoom().getId())
+			.distinct()
+			.collect(Collectors.toList());
+	}
+
+	// 채팅방에 유저수 구하기
+	private Map<Long, Long> getUserCountByChatRoomId(List<Long> chatRoomIds) {
+		return chatRoomIds.stream()
+			.collect(Collectors.toMap(chatRoomId -> chatRoomId, userChatRoomRepository::countByChatRoomId));
+	}
+
+	// 채팅방에 안읽은 메세지 수 구하기
+	private Map<Long, Long> getUnreadMessageCountByChatRoomId(Long userId, List<Long> chatRoomIds) {
+		return chatRoomIds.stream()
+			.collect(Collectors.toMap(chatRoomId -> chatRoomId, chatRoomId -> {
+				LocalDateTime lastVisitedTime = userChatRoomRepository.findConfigTime(userId, chatRoomId);
+				return (lastVisitedTime == null) ?
+					chatRepository.countByChatRoomId(chatRoomId) :
+					chatRepository.countByChatRoomIdAndSendTimeAfter(chatRoomId, lastVisitedTime);
+			}));
+	}
+
+	// ChatRoom을 ChatRoomResponseDTO로 변환
+	private ChatRoomResponseDTO convertToChatRoomResponseDTO(ChatRoom chatRoom, Long userCount,
+		Long unreadMessageCount) {
+		return ChatRoomResponseDTO.builder()
+			.title(chatRoom.getTitle())
+			.type(chatRoom.getType())
+			.lastMessageContent(chatRoom.getLastMessageContent())
+			.lastMessageTime(chatRoom.getLastMessageTime())
+			.userCount(userCount)
+			.unreadMessageCnt(unreadMessageCount)
+			.build();
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/global/Initializer/DatabaseInitializer.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/Initializer/DatabaseInitializer.java
@@ -1,0 +1,45 @@
+package com.goorm.insideout.global.Initializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.exception.ModongException;
+import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.user.repository.UserRepository;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DatabaseInitializer {
+
+	private static final Logger logger = LoggerFactory.getLogger(DatabaseInitializer.class);
+
+	private final UserRepository userRepository;
+
+	@PostConstruct
+	public void initialize() {
+		try {
+			// Check if SYSTEM_USER already exists
+			if (userRepository.findByEmail("system@insideout.com").isEmpty()) {
+				User systemUser = User.builder()
+					.email("system@insideout.com")
+					.password("systempass") // 시스템 사용자이므로, 안전한 비밀번호를 사용하세요.
+					.name("SYSTEM")
+					.build();
+
+				userRepository.save(systemUser);
+				logger.info("SYSTEM_USER has been successfully created.");
+			} else {
+				logger.info("SYSTEM_USER already exists.");
+			}
+		} catch (Exception e) {
+			logger.error("An error occurred while initializing the database.", e);
+			// Optionally, rethrow the exception if necessary
+			throw ModongException.from(ErrorCode.INTERNAL_SEVER_ERROR);
+		}
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/controller/UserChatRoomController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/controller/UserChatRoomController.java
@@ -1,0 +1,49 @@
+package com.goorm.insideout.userchatroom.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.goorm.insideout.auth.dto.CustomUserDetails;
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.response.ApiResponse;
+import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.userchatroom.service.UserChatRoomService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserChatRoomController {
+
+	private final UserChatRoomService userChatRoomService;
+
+	// 채팅방 입장
+	@PostMapping("/chatroom/{chatRoomId}/enter")
+	public ApiResponse enterChatRoom(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable Long chatRoomId) {
+		User user = customUserDetails.getUser();
+		try {
+			userChatRoomService.updateChatRoomConfigTime(chatRoomId, user);
+			return new ApiResponse<>(ErrorCode.REQUEST_OK);
+		} catch (Exception e) {
+			return new ApiResponse<>(ErrorCode.INVALID_REQUEST);
+		}
+	}
+
+	// 채팅방 퇴장
+	@PostMapping("/chatroom/{chatRoomId}/exit")
+	public ApiResponse exitChatRoom(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable Long chatRoomId) {
+		User user = customUserDetails.getUser();
+		try {
+			userChatRoomService.updateChatRoomConfigTime(chatRoomId, user);
+			return new ApiResponse<>(ErrorCode.REQUEST_OK);
+		} catch (Exception e) {
+			return new ApiResponse<>(ErrorCode.INVALID_REQUEST);
+		}
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/domain/UserChatRoom.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/domain/UserChatRoom.java
@@ -1,0 +1,46 @@
+package com.goorm.insideout.userchatroom.domain;
+
+import java.time.LocalDateTime;
+
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "UserChatRooms")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserChatRoom {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "config_time")
+	private LocalDateTime configTime;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "chat_room_id", nullable = false)
+	private ChatRoom chatRoom;
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/repository/UserChatRoomRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/repository/UserChatRoomRepository.java
@@ -1,0 +1,26 @@
+package com.goorm.insideout.userchatroom.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.userchatroom.domain.UserChatRoom;
+
+public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long> {
+	List<UserChatRoom> findByUserId(Long userId); // User 엔티티의 ID로 조회
+
+	void deleteByUserIdAndChatRoomId(Long userId, Long chatRoomId);
+
+	Long countByChatRoomId(Long chatRoomId);
+	Optional<UserChatRoom> findByUserAndChatRoom(User user, ChatRoom chatRoom);
+
+	@Query("SELECT ucr.configTime FROM UserChatRoom ucr WHERE ucr.user.id = :userId AND ucr.chatRoom.id = :chatRoomId")
+	LocalDateTime findConfigTime(@Param("userId") Long userId, @Param("chatRoomId") Long chatRoomId);
+
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/service/UserChatRoomService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/userchatroom/service/UserChatRoomService.java
@@ -1,0 +1,120 @@
+package com.goorm.insideout.userchatroom.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goorm.insideout.chat.domain.Chat;
+import com.goorm.insideout.chat.dto.response.ChatResponseDTO;
+import com.goorm.insideout.chat.repository.ChatRepository;
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.exception.ModongException;
+import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.user.repository.UserRepository;
+import com.goorm.insideout.userchatroom.domain.UserChatRoom;
+import com.goorm.insideout.userchatroom.repository.UserChatRoomRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserChatRoomService {
+
+	private final UserChatRoomRepository userChatRoomRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatRepository chatRepository;
+	private final UserRepository userRepository;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	// 사용자 초대
+	@Transactional
+	public void inviteUserToChatRoom(Long chatRoomId, User user) {
+		ChatRoom chatRoom = findChatRoomById(chatRoomId);
+		saveUserChatRoom(chatRoom, user);
+		Chat chat = createInviteMessage(chatRoom, user);
+		sendInviteMessage(chat);
+	}
+
+	// 채팅방 나가기 및 삭제
+	@Transactional
+	public void userLeaveChatRoom(Long userId, Long chatRoomId) {
+		removeUserFromChatRoom(userId, chatRoomId);
+		deleteChatRoomIfEmpty(chatRoomId);
+	}
+
+	// 채팅방 입장 및 나가기 시 configTime 업데이트
+	@Transactional
+	public void updateChatRoomConfigTime(Long chatRoomId, User user) {
+		updateConfigTime(chatRoomId, user);
+	}
+
+	// 유저와 채팅방 관계 저장
+	private void saveUserChatRoom(ChatRoom chatRoom, User user) {
+		UserChatRoom userChatRoom = UserChatRoom.builder()
+			.user(user)
+			.chatRoom(chatRoom)
+			.configTime(null)
+			.build();
+		userChatRoomRepository.save(userChatRoom);
+	}
+
+	// 유저와 채팅방 관계 삭제
+	private void removeUserFromChatRoom(Long userId, Long chatRoomId) {
+		userChatRoomRepository.deleteByUserIdAndChatRoomId(userId, chatRoomId);
+	}
+
+	// 채팅방에 입/퇴장시 시간 기록
+	private void updateConfigTime(Long chatRoomId, User user) {
+		ChatRoom chatRoom = findChatRoomById(chatRoomId);
+		UserChatRoom userChatRoom = userChatRoomRepository.findByUserAndChatRoom(user, chatRoom)
+			.orElseThrow(() -> ModongException.from(ErrorCode.CHAT_NOT_AUTHORIZED));
+		userChatRoom.setConfigTime(LocalDateTime.now());
+		userChatRoomRepository.save(userChatRoom);
+	}
+
+	// 채팅방에 사람이 없으면 채팅방 삭제
+	private void deleteChatRoomIfEmpty(Long chatRoomId) {
+		if (userChatRoomRepository.countByChatRoomId(chatRoomId) == 0) {
+			chatRoomRepository.deleteById(chatRoomId); // 사용자 수가 0이면 채팅방 삭제
+		}
+	}
+
+	// 시스템의 초대메세지 생성
+	private Chat createInviteMessage(ChatRoom chatRoom, User user) {
+		String enterMessage = user.getName() + "님이 채팅방에 초대되었습니다.";
+		User systemUser = userRepository.findByEmail("system@insideout.com")
+			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
+		return Chat.builder()
+			.content(enterMessage)
+			.sendTime(LocalDateTime.now())
+			.chatRoom(chatRoom)
+			.user(systemUser)
+			.build();
+	}
+
+	// 메세지 저장 및 실시간 전송
+	private void sendInviteMessage(Chat chat) {
+		chatRepository.save(chat);
+		ChatResponseDTO chatResponseDTO = convertToChatResponseDTO(chat);
+		messagingTemplate.convertAndSend("/sub/chatRoom/" + chat.getChatRoom().getId(), chatResponseDTO);
+	}
+
+	// dto로 치환
+	private ChatResponseDTO convertToChatResponseDTO(Chat chat) {
+		return ChatResponseDTO.builder()
+			.content(chat.getContent())
+			.sendTime(chat.getSendTime())
+			.sender(chat.getUser().getName())
+			.build();
+	}
+
+	// 채팅방 찾기 및 유효성 검사
+	private ChatRoom findChatRoomById(Long chatRoomId) {
+		return chatRoomRepository.findById(chatRoomId)
+			.orElseThrow(() -> ModongException.from(ErrorCode.CHATROOM_NOT_FOUND));
+	}
+}

--- a/Inside-Out/src/test/java/com/goorm/insideout/chat/service/ChatServiceTest.java
+++ b/Inside-Out/src/test/java/com/goorm/insideout/chat/service/ChatServiceTest.java
@@ -1,0 +1,153 @@
+package com.goorm.insideout.chat.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.goorm.insideout.chat.domain.Chat;
+import com.goorm.insideout.chat.dto.request.ChatRequestDTO;
+import com.goorm.insideout.chat.dto.response.ChatResponseDTO;
+import com.goorm.insideout.chat.repository.ChatRepository;
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
+import com.goorm.insideout.global.exception.ErrorCode;
+import com.goorm.insideout.global.exception.ModongException;
+import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.user.repository.UserRepository;
+import com.goorm.insideout.userchatroom.repository.UserChatRoomRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatServiceTest {
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private ChatRepository chatRepository;
+
+	@Mock
+	private UserChatRoomRepository userChatRoomRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private ChatService chatService;
+
+	private User testUser;
+	private ChatRoom testChatRoom;
+	private ChatRequestDTO chatRequestDTO;
+	private Chat testChat;
+	private LocalDateTime lastVisitedTime;
+
+	@BeforeEach
+	public void setUp() {
+		testUser = User.builder()
+			.id(1L)
+			.email("test@example.com")
+			.password("password")
+			.name("Test User")
+			.build();
+
+		testChatRoom = ChatRoom.builder()
+			.id(1L)
+			.title("Test Chat Room")
+			.build();
+
+		chatRequestDTO = new ChatRequestDTO("Hello World");
+
+		testChat = Chat.builder()
+			.id(1L)
+			.content("Hello World")
+			.chatRoom(testChatRoom)
+			.user(testUser)
+			.sendTime(LocalDateTime.now())
+			.build();
+
+		lastVisitedTime = LocalDateTime.now().minusDays(1);
+	}
+
+	@Test
+	public void testCreateChat() {
+		// Mock 설정
+		when(chatRoomRepository.findById(testChatRoom.getId())).thenReturn(Optional.of(testChatRoom));
+		when(chatRepository.save(any(Chat.class))).thenReturn(testChat);
+		when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(new User()));
+		// Call the service method
+		Chat createdChat = chatService.createChat(testChatRoom.getId(), chatRequestDTO, testUser.getEmail());
+
+		// Assertions
+		assertNotNull(createdChat);
+		assertEquals(testChat.getContent(), createdChat.getContent());
+		assertEquals(testChat.getUser(), createdChat.getUser());
+		assertEquals(testChat.getChatRoom(), createdChat.getChatRoom());
+
+		// Verify interactions
+		verify(chatRoomRepository).findById(testChatRoom.getId());
+		verify(chatRepository).save(any(Chat.class));
+	}
+
+	@Test
+	public void testCreateChat_ChatRoomNotFound() {
+		when(chatRoomRepository.findById(testChatRoom.getId())).thenReturn(Optional.empty());
+
+		ModongException thrown = assertThrows(ModongException.class, () -> {
+			chatService.createChat(testChatRoom.getId(), chatRequestDTO, testUser.getEmail());
+		});
+
+		assertEquals(ErrorCode.CHATROOM_NOT_FOUND, thrown.getErrorCode());
+	}
+
+	@Test
+	public void testGetUnreadMessages_WithLastVisitedTime() {
+		List<Chat> unreadChats = Arrays.asList(testChat);
+
+		List<ChatResponseDTO> expectedResponse = unreadChats.stream()
+			.map(chat -> ChatResponseDTO.builder()
+				.content(chat.getContent())
+				.sendTime(chat.getSendTime())
+				.sender(chat.getUser().getName())
+				.build())
+			.collect(Collectors.toList());
+
+		when(userChatRoomRepository.findConfigTime(testUser.getId(), testChatRoom.getId())).thenReturn(lastVisitedTime);
+		when(chatRepository.findAllUnreadMessages(testChatRoom.getId(), lastVisitedTime)).thenReturn(unreadChats);
+
+		List<ChatResponseDTO> result = chatService.getUnreadMessages(testUser.getId(), testChatRoom.getId());
+
+		assertEquals(expectedResponse, result);
+	}
+
+	@Test
+	public void testGetUnreadMessages_WithoutLastVisitedTime() {
+		List<Chat> allChats = Arrays.asList(testChat);
+
+		List<ChatResponseDTO> expectedResponse = allChats.stream()
+			.map(chat -> ChatResponseDTO.builder()
+				.content(chat.getContent())
+				.sendTime(chat.getSendTime())
+				.sender(chat.getUser().getName())
+				.build())
+			.collect(Collectors.toList());
+
+		when(userChatRoomRepository.findConfigTime(testUser.getId(), testChatRoom.getId())).thenReturn(null);
+		when(chatRepository.findAllByChatRoomId(testChatRoom.getId())).thenReturn(allChats);
+
+		List<ChatResponseDTO> result = chatService.getUnreadMessages(testUser.getId(), testChatRoom.getId());
+
+		assertEquals(expectedResponse, result);
+	}
+}

--- a/Inside-Out/src/test/java/com/goorm/insideout/chatroom/service/ChatRoomServiceTest.java
+++ b/Inside-Out/src/test/java/com/goorm/insideout/chatroom/service/ChatRoomServiceTest.java
@@ -1,0 +1,159 @@
+package com.goorm.insideout.chatroom.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.goorm.insideout.chat.repository.ChatRepository;
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.chatroom.domain.ChatRoomType;
+import com.goorm.insideout.chatroom.dto.response.ChatRoomResponseDTO;
+import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
+import com.goorm.insideout.userchatroom.domain.UserChatRoom;
+import com.goorm.insideout.userchatroom.repository.UserChatRoomRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private ChatRepository chatRepository;
+
+	@Mock
+	private UserChatRoomRepository userChatRoomRepository;
+
+	@InjectMocks
+	private ChatRoomService chatRoomService;
+
+	private ChatRoom testChatRoom;
+	private UserChatRoom testUserChatRoom;
+	private Long userId;
+	private Long chatRoomId;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		chatRoomId = 1L;
+
+		testChatRoom = ChatRoom.builder()
+			.id(chatRoomId)
+			.associatedId(1L)
+			.title("Test Chat Room")
+			.type(ChatRoomType.CLUB)
+			.build();
+
+		testUserChatRoom = UserChatRoom.builder()
+			.chatRoom(testChatRoom)
+			.build();
+	}
+
+	@Test
+	void testCreateChatRoom() {
+		// Given
+		ChatRoom chatRoom = ChatRoom.builder()
+			.id(chatRoomId)
+			.associatedId(1L)
+			.title("Test Chat Room")
+			.type(ChatRoomType.CLUB)
+			.build();
+
+		// Mock setup
+		when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(chatRoom);
+
+		// When
+		ChatRoom createdChatRoom = chatRoomService.createChatRoom(1L, "Test Chat Room", ChatRoomType.CLUB);
+
+		// Then
+		assertNotNull(createdChatRoom, "The created chat room should not be null");
+		assertEquals(chatRoomId, createdChatRoom.getId(), "The chat room ID should match");
+		assertEquals("Test Chat Room", createdChatRoom.getTitle(), "The chat room title should match");
+		assertEquals(ChatRoomType.CLUB, createdChatRoom.getType(), "The chat room type should match");
+	}
+
+	@Test
+	void testGetChatRoomsByUserId() {
+		// Given
+		Long userId = 1L;
+		Long chatRoomId = 1L;
+
+		ChatRoom chatRoom = ChatRoom.builder()
+			.id(chatRoomId)
+			.title("Chat Room")
+			.type(ChatRoomType.CLUB)  // Ensure the type is set
+			.lastMessageContent("Last message")
+			.lastMessageTime(LocalDateTime.now())
+			.build();
+
+		List<UserChatRoom> userChatRooms = Collections.singletonList(UserChatRoom.builder()
+			.chatRoom(chatRoom)
+			.build());
+
+		// Mock setup
+		when(userChatRoomRepository.findByUserId(userId)).thenReturn(userChatRooms);
+		when(chatRoomRepository.findAllById(Collections.singletonList(chatRoomId)))
+			.thenReturn(Collections.singletonList(chatRoom));
+		when(userChatRoomRepository.countByChatRoomId(chatRoomId)).thenReturn(1L);
+
+		// When
+		List<ChatRoomResponseDTO> chatRooms = chatRoomService.getChatRoomsByUserId(userId);
+
+		// Then
+		assertNotNull(chatRooms);
+		assertEquals(1, chatRooms.size());
+
+		ChatRoomResponseDTO resultDTO = chatRooms.get(0);
+		assertEquals("Chat Room", resultDTO.getTitle());
+		assertEquals(ChatRoomType.CLUB, resultDTO.getType());  // Ensure the type is checked
+		assertEquals("Last message", resultDTO.getLastMessageContent());
+		assertEquals(1L, resultDTO.getUserCount());
+		assertEquals(0L, resultDTO.getUnreadMessageCnt());
+	}
+
+	@Test
+	void testGetClubRoomsByUserId() {
+		// Test implementation similar to testGetChatRoomsByUserId but filtering for CLUB rooms
+		when(userChatRoomRepository.findByUserId(userId)).thenReturn(Collections.singletonList(testUserChatRoom));
+		when(chatRoomRepository.findAllById(Collections.singletonList(chatRoomId)))
+			.thenReturn(Collections.singletonList(testChatRoom));
+
+		// Call the service method
+		List<ChatRoomResponseDTO> clubRooms = chatRoomService.getClubRoomsByUserId(userId);
+
+		// Validate the results
+		assertNotNull(clubRooms);
+		assertEquals(1, clubRooms.size());
+		assertEquals(ChatRoomType.CLUB, clubRooms.get(0).getType());
+	}
+
+	@Test
+	void testGetMeetingRoomsByUserId() {
+		// Test implementation similar to testGetChatRoomsByUserId but filtering for MEETING rooms
+		ChatRoom meetingRoom = ChatRoom.builder().id(chatRoomId).title("Meeting Room").type(ChatRoomType.MEETING).build();
+		when(userChatRoomRepository.findByUserId(userId)).thenReturn(Collections.singletonList(testUserChatRoom));
+		when(chatRoomRepository.findAllById(Collections.singletonList(chatRoomId)))
+			.thenReturn(Collections.singletonList(meetingRoom));
+
+		// Call the service method
+		List<ChatRoomResponseDTO> meetingRooms = chatRoomService.getMeetingRoomsByUserId(userId);
+
+		// Validate the results
+		assertNotNull(meetingRooms);
+		assertEquals(1, meetingRooms.size());
+		assertEquals(ChatRoomType.MEETING, meetingRooms.get(0).getType());
+	}
+}

--- a/Inside-Out/src/test/java/com/goorm/insideout/userchatroom/service/UserChatRoomServiceTest.java
+++ b/Inside-Out/src/test/java/com/goorm/insideout/userchatroom/service/UserChatRoomServiceTest.java
@@ -1,0 +1,118 @@
+package com.goorm.insideout.userchatroom.service;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+
+import com.goorm.insideout.chat.domain.Chat;
+import com.goorm.insideout.chat.dto.response.ChatResponseDTO;
+import com.goorm.insideout.chat.repository.ChatRepository;
+import com.goorm.insideout.chatroom.domain.ChatRoom;
+import com.goorm.insideout.chatroom.repository.ChatRoomRepository;
+import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.user.repository.UserRepository;
+import com.goorm.insideout.userchatroom.domain.UserChatRoom;
+import com.goorm.insideout.userchatroom.repository.UserChatRoomRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class UserChatRoomServiceTest {
+
+	@InjectMocks
+	private UserChatRoomService userChatRoomService;
+
+	@Mock
+	private SimpMessageSendingOperations messagingTemplate;
+
+	@Mock
+	private UserChatRoomRepository userChatRoomRepository;
+
+	@Mock
+	private ChatRepository chatRepository;
+
+	@Mock
+	private ChatRoomRepository chatRoomRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Test
+	public void testInviteUserToChatRoom() {
+		Long chatRoomId = 1L;
+		Long userId = 1L;
+
+		ChatRoom chatRoom = ChatRoom.builder().id(chatRoomId).build();
+		User user = User.builder().id(userId).name("Test User").build();
+		User systemUser = User.builder().email("system@insideout.com").build();
+
+		when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+		when(userRepository.findByEmail("system@insideout.com")).thenReturn(Optional.of(systemUser));
+
+		userChatRoomService.inviteUserToChatRoom(chatRoomId, user);
+
+		// Verify UserChatRoom saving
+		verify(userChatRoomRepository, times(1)).save(any(UserChatRoom.class));
+
+		// Verify Chat saving
+		verify(chatRepository, times(1)).save(any(Chat.class));
+
+		// Verify message sending
+		verify(messagingTemplate, times(1)).convertAndSend(any(String.class), any(ChatResponseDTO.class));
+	}
+
+	@Test
+	public void testUserLeaveChatRoom() {
+		Long userId = 1L;
+		Long chatRoomId = 1L;
+
+		when(userChatRoomRepository.countByChatRoomId(chatRoomId)).thenReturn(1L);
+
+		userChatRoomService.userLeaveChatRoom(userId, chatRoomId);
+
+		// Verify user removal from chat room
+		verify(userChatRoomRepository, times(1)).deleteByUserIdAndChatRoomId(userId, chatRoomId);
+
+		// Verify chat room deletion not called
+		verify(chatRoomRepository, never()).deleteById(chatRoomId);
+	}
+
+	@Test
+	public void testUserLeaveChatRoomAndDelete() {
+		Long userId = 1L;
+		Long chatRoomId = 1L;
+
+		when(userChatRoomRepository.countByChatRoomId(chatRoomId)).thenReturn(0L);
+
+		userChatRoomService.userLeaveChatRoom(userId, chatRoomId);
+
+		// Verify user removal from chat room
+		verify(userChatRoomRepository, times(1)).deleteByUserIdAndChatRoomId(userId, chatRoomId);
+
+		// Verify chat room deletion
+		verify(chatRoomRepository, times(1)).deleteById(chatRoomId);
+	}
+
+	@Test
+	public void testUpdateChatRoomConfigTime() {
+		Long chatRoomId = 1L;
+		Long userId = 1L;
+
+		User user = User.builder().id(userId).build();
+		ChatRoom chatRoom = ChatRoom.builder().id(chatRoomId).build();
+
+		when(chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(chatRoom));
+		when(userChatRoomRepository.findByUserAndChatRoom(user, chatRoom))
+			.thenReturn(Optional.of(UserChatRoom.builder().build()));
+
+		userChatRoomService.updateChatRoomConfigTime(chatRoomId, user);
+
+		// Verify configTime update
+		verify(userChatRoomRepository, times(1)).save(any(UserChatRoom.class));
+	}
+}


### PR DESCRIPTION
#️⃣ 연관된 이슈
ex) #40 

📝 작업 내용
✅ 기능 구현

채팅방에 관한 기능들을 구현했습니다.

채팅방 메세지 로그 조회
나의 채팅방 목록 조회
나의 동아리 채팅방 목록 조회
나의 모임 채팅방 목록 조회
채팅방 입장
채팅방 퇴장
채팅방 초대(생성) 및 나가기(삭제)
초대 시 system 메세지 보내기
등을 구현했습니다.

✅ 특이 사항
테스트 코드가 정확한지 모르겠습니다.. 포스트맨이랑 apic을 통해 검사해본 결과 이상은 없었습니다. 
 
📷 스크린샷 (선택)
💬 리뷰 요구사항 (선택)
서비스 계층의 개념이 부족해 리펙토링을 한번 거쳤지만 헷갈리는게 많습니다. 따갑고도 따뜻한 리뷰 부탁드립니다!