### PR TITLE
유저 프로필 및 회원가입시 관련 정보입력 기능 구현

### DIFF
--- a/Inside-Out/src/main/java/com/goorm/insideout/auth/config/SecurityConfig.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/auth/config/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
 		"/api/reissue",
     	"/api/clubs",
     	"/api/clubs/{clubId}",
+		"/api/check-email",
+		"/api/check-nickname",
 		"/"
 	};
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/auth/config/SecurityConfig.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/auth/config/SecurityConfig.java
@@ -49,8 +49,8 @@ public class SecurityConfig {
 		"/api/login/**",
 		"/api/join",
 		"/api/reissue",
-    "/api/clubs",
-    "/api/clubs/{clubId}",
+    	"/api/clubs",
+    	"/api/clubs/{clubId}",
 		"/"
 	};
 
@@ -75,7 +75,7 @@ public class SecurityConfig {
 					@Override
 					public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
 						CorsConfiguration configuration = new CorsConfiguration();
-						configuration.setAllowedOrigins(List.of("https://localhost:3000"));
+						configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173","https://localhost:3000"));
 						configuration.setAllowedMethods(Collections.singletonList("*"));
 						configuration.setAllowCredentials(true);
 						configuration.setAllowedHeaders(Collections.singletonList("*"));

--- a/Inside-Out/src/main/java/com/goorm/insideout/auth/config/SecurityConfig.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/auth/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
 					@Override
 					public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
 						CorsConfiguration configuration = new CorsConfiguration();
-						configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173","https://localhost:3000"));
+						configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173","http://localhost:3000"));
 						configuration.setAllowedMethods(Collections.singletonList("*"));
 						configuration.setAllowCredentials(true);
 						configuration.setAllowedHeaders(Collections.singletonList("*"));

--- a/Inside-Out/src/main/java/com/goorm/insideout/auth/filter/CustomOAuthLoginHandler.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/auth/filter/CustomOAuthLoginHandler.java
@@ -39,7 +39,9 @@ public class CustomOAuthLoginHandler extends SimpleUrlAuthenticationSuccessHandl
 		RefreshToken refreshToken = new RefreshToken(refresh,userEmail);
 		refreshTokenRepository.save(refreshToken);
 		// reissue 요청으로 리다이렉트하기
-		response.sendRedirect("http://localhost:3000/?action=reissue");
+		//response.sendRedirect("http://localhost:3000/?action=reissue");
+		response.sendRedirect("http://localhost:5173/reissue");
+		//response.sendRedirect("https://modong.link/reissue");
 	}
 	private ResponseCookie createCookie(String key, String value) {
 		return ResponseCookie.from(key, value)

--- a/Inside-Out/src/main/java/com/goorm/insideout/auth/utils/JWTUtil.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/auth/utils/JWTUtil.java
@@ -9,6 +9,8 @@ import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 
 @Component
@@ -43,13 +45,13 @@ public class JWTUtil {
 
 	//claim 에서 토큰 만료 여부 추출
 	public Boolean isExpired(String token) {
-		return Jwts.parser()
-			.verifyWith(secretKey)
-			.build()
-			.parseSignedClaims(token)
-			.getPayload()
-			.getExpiration()
-			.before(new Date());
+		try {
+			Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+			return false;
+		} catch (ExpiredJwtException e) {
+			// 토큰이 만료된 경우
+			return true;
+		}
 	}
 
 	//JWT 토큰 생성 Claim 에는 토큰 종류와 email 만 담음
@@ -69,7 +71,11 @@ public class JWTUtil {
 		try {
 			Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
 			return true;
+		} catch (ExpiredJwtException e) {
+			// 토큰이 만료된 경우
+			return true;
 		} catch (Exception e) {
+			// 서명이 잘못됬거나 형식이 잘못됐을경우
 			return false;
 		}
 	}

--- a/Inside-Out/src/main/java/com/goorm/insideout/global/config/CorsMvcConfig.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/config/CorsMvcConfig.java
@@ -11,7 +11,7 @@ public class CorsMvcConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry corsRegistry) {
 
 		corsRegistry.addMapping("/**")
-			.allowedOrigins("http://localhost:5173","https://localhost:3000")
+			.allowedOrigins("http://localhost:5173","http://localhost:3000")
 			.allowedMethods("GET", "POST", "PUT", "DELETE")
 			.allowedHeaders("Authorization", "Content-Type")
 			.exposedHeaders("Authorization")

--- a/Inside-Out/src/main/java/com/goorm/insideout/global/config/CorsMvcConfig.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/global/config/CorsMvcConfig.java
@@ -11,7 +11,7 @@ public class CorsMvcConfig implements WebMvcConfigurer {
 	public void addCorsMappings(CorsRegistry corsRegistry) {
 
 		corsRegistry.addMapping("/**")
-			.allowedOrigins("https://localhost:3000")
+			.allowedOrigins("http://localhost:5173","https://localhost:3000")
 			.allowedMethods("GET", "POST", "PUT", "DELETE")
 			.allowedHeaders("Authorization", "Content-Type")
 			.exposedHeaders("Authorization")

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserJoinController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserJoinController.java
@@ -19,6 +19,7 @@ import com.goorm.insideout.global.exception.ModongException;
 import com.goorm.insideout.global.response.ApiResponse;
 import com.goorm.insideout.user.dto.request.CheckEmailRequest;
 import com.goorm.insideout.user.dto.request.CheckNicknameRequest;
+import com.goorm.insideout.user.dto.request.SocialJoinRequest;
 import com.goorm.insideout.user.dto.request.UserJoinRequestDTO;
 import com.goorm.insideout.user.service.UserJoinService;
 
@@ -37,22 +38,33 @@ public class UserJoinController {
 		service.join(userJoinRequest);
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
+
 	@GetMapping("/check-email")
 	public ApiResponse checkEmail(@Validated @RequestBody CheckEmailRequest checkEmailRequest, Errors errors) {
 		validateRequest(errors);
 		service.validateExistEmail(checkEmailRequest.getEmail());
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
+
 	@GetMapping("/check-nickname")
 	public ApiResponse checkNickname(@Validated @RequestBody CheckNicknameRequest checkNicknameRequest, Errors errors) {
 		validateRequest(errors);
 		service.validateExistEmail(checkNicknameRequest.getNickname());
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
+
 	@GetMapping("/oauth2/userInfo")
-	public ApiResponse checkFirstLogin(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletResponse response) throws
+	public ApiResponse checkFirstLogin(@AuthenticationPrincipal CustomUserDetails userDetails,
+		HttpServletResponse response) throws
 		IOException {
-		service.checkFirstLogin(userDetails.getUser(),response);
+		service.checkFirstLogin(userDetails.getUser(), response);
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+
+	@PostMapping("/oauth2/userInfo")
+	public ApiResponse insertUserInfo(@RequestBody SocialJoinRequest socialJoinRequest,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		service.socialJoin(userDetails.getUser(), socialJoinRequest);
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
 
@@ -60,7 +72,7 @@ public class UserJoinController {
 		if (errors.hasErrors()) {
 			errors.getFieldErrors().forEach(error -> {
 				String errorMessage = error.getDefaultMessage();
-				throw ModongException.from(ErrorCode.INVALID_REQUEST,errorMessage);
+				throw ModongException.from(ErrorCode.INVALID_REQUEST, errorMessage);
 			});
 		}
 	}

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserJoinController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserJoinController.java
@@ -3,6 +3,7 @@ package com.goorm.insideout.user.controller;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.goorm.insideout.global.exception.ErrorCode;
 import com.goorm.insideout.global.exception.ModongException;
 import com.goorm.insideout.global.response.ApiResponse;
+import com.goorm.insideout.user.dto.request.CheckEmailRequest;
+import com.goorm.insideout.user.dto.request.CheckNicknameRequest;
 import com.goorm.insideout.user.dto.request.UserJoinRequestDTO;
 import com.goorm.insideout.user.service.UserJoinService;
 
@@ -26,6 +29,18 @@ public class UserJoinController {
 	public ApiResponse join(@Validated @RequestBody UserJoinRequestDTO userJoinRequest, Errors errors) {
 		validateRequest(errors);
 		service.join(userJoinRequest);
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+	@GetMapping("/check-email")
+	public ApiResponse checkEmail(@Validated @RequestBody CheckEmailRequest checkEmailRequest, Errors errors) {
+		validateRequest(errors);
+		service.validateExistEmail(checkEmailRequest.getEmail());
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+	@GetMapping("/check-nickname")
+	public ApiResponse checkNickname(@Validated @RequestBody CheckNicknameRequest checkNicknameRequest, Errors errors) {
+		validateRequest(errors);
+		service.validateExistEmail(checkNicknameRequest.getNickname());
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserJoinController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserJoinController.java
@@ -1,5 +1,9 @@
 package com.goorm.insideout.user.controller;
 
+import java.io.IOException;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.annotation.Validated;
@@ -9,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.goorm.insideout.auth.dto.CustomUserDetails;
 import com.goorm.insideout.global.exception.ErrorCode;
 import com.goorm.insideout.global.exception.ModongException;
 import com.goorm.insideout.global.response.ApiResponse;
@@ -17,6 +22,7 @@ import com.goorm.insideout.user.dto.request.CheckNicknameRequest;
 import com.goorm.insideout.user.dto.request.UserJoinRequestDTO;
 import com.goorm.insideout.user.service.UserJoinService;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -41,6 +47,12 @@ public class UserJoinController {
 	public ApiResponse checkNickname(@Validated @RequestBody CheckNicknameRequest checkNicknameRequest, Errors errors) {
 		validateRequest(errors);
 		service.validateExistEmail(checkNicknameRequest.getNickname());
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+	@GetMapping("/oauth2/userInfo")
+	public ApiResponse checkFirstLogin(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletResponse response) throws
+		IOException {
+		service.checkFirstLogin(userDetails.getUser(),response);
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/Gender.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/Gender.java
@@ -1,0 +1,20 @@
+package com.goorm.insideout.user.domain;
+
+import static com.goorm.insideout.global.exception.ErrorCode.*;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.goorm.insideout.global.exception.ModongException;
+
+import lombok.Getter;
+
+@Getter
+public enum Gender {
+	MALE("남성"),
+	FEMALE("여성");
+
+	private final String name;
+
+	Gender(String name) {
+		this.name = name;
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
@@ -1,10 +1,21 @@
 package com.goorm.insideout.user.domain;
 
+import java.time.LocalDate;
+import java.util.Set;
+
+import com.goorm.insideout.meeting.domain.Category;
+
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,4 +44,20 @@ public class User {
 	@Column(nullable = false)
 	private String name;
 
+	private String profileImage;
+
+	private String nickname;
+
+	private String location;
+
+	private LocalDate birthDate;
+
+	private String phoneNumber;
+
+	@ElementCollection(targetClass = Category.class, fetch = FetchType.LAZY)
+	@Enumerated(EnumType.STRING)
+	private Set<Category> interests;
+
+	@Enumerated(EnumType.STRING)
+	private Gender gender;
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/CheckEmailRequest.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/CheckEmailRequest.java
@@ -1,0 +1,12 @@
+package com.goorm.insideout.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CheckEmailRequest {
+	@NotBlank(message = "email은 필수 입니다")
+	@Email(message = "올바른 email 형식이 아닙니다")
+	private String email;
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/CheckNicknameRequest.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/CheckNicknameRequest.java
@@ -1,0 +1,10 @@
+package com.goorm.insideout.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CheckNicknameRequest {
+	@NotBlank(message = "이름은 필수 입니다")
+	private String nickname;
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/SocialJoinRequest.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/SocialJoinRequest.java
@@ -1,0 +1,21 @@
+package com.goorm.insideout.user.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class SocialJoinRequest {
+	private String nickName;
+
+	private String phoneNumber;
+
+	private String location;
+
+	private String gender;
+
+	private List<String> category;
+
+	private LocalDate birthDate;
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/UserJoinRequestDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/UserJoinRequestDTO.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
+@Setter
 public class UserJoinRequestDTO {
 	@NotBlank(message = "email은 필수 입니다")
 	@Email(message = "올바른 email 형식이 아닙니다")

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/UserJoinRequestDTO.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/UserJoinRequestDTO.java
@@ -1,12 +1,14 @@
 package com.goorm.insideout.user.dto.request;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
-@Setter
 @Getter
 public class UserJoinRequestDTO {
 	@NotBlank(message = "email은 필수 입니다")
@@ -19,4 +21,16 @@ public class UserJoinRequestDTO {
 
 	@NotBlank(message = "이름은 필수 입니다")
 	private String name;
+
+	private String nickName;
+
+	private String phoneNumber;
+
+	private String location;
+
+	private String gender;
+
+	private List<String> category;
+
+	private LocalDate birthDate;
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/repository/UserRepository.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/repository/UserRepository.java
@@ -3,10 +3,13 @@ package com.goorm.insideout.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.goorm.insideout.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Boolean existsByEmail(String email);
+	Boolean existsByNickname(String nickname);
 	Optional<User> findByEmail(String email);
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserJoinService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserJoinService.java
@@ -1,16 +1,23 @@
 package com.goorm.insideout.user.service;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.validation.Errors;
-import org.springframework.validation.FieldError;
 
 import com.goorm.insideout.global.exception.ErrorCode;
 import com.goorm.insideout.global.exception.ModongException;
+import com.goorm.insideout.meeting.domain.Category;
+import com.goorm.insideout.user.domain.Gender;
 import com.goorm.insideout.user.domain.User;
+import com.goorm.insideout.user.dto.request.CheckEmailRequest;
+import com.goorm.insideout.user.dto.request.CheckNicknameRequest;
 import com.goorm.insideout.user.dto.request.UserJoinRequestDTO;
 import com.goorm.insideout.user.repository.UserRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -19,21 +26,38 @@ public class UserJoinService {
 	private final UserRepository userRepository;
 	private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
+	@Transactional
 	public void join(UserJoinRequestDTO userJoinRequest) {
-
-		validateExistUser(userJoinRequest);
+		List<String> categoryDTO = userJoinRequest.getCategory();
+		Set<Category> categorySet = new HashSet<>();
+		for (String category : categoryDTO) {
+			categorySet.add(Category.valueOf(category));
+		}
+		validateExistEmail(userJoinRequest.getEmail());
+		validateExistNickname(userJoinRequest.getName());
 		User joinUser = User.builder()
 			.email(userJoinRequest.getEmail())
 			.password(bCryptPasswordEncoder.encode(userJoinRequest.getPassword()))
 			.name(userJoinRequest.getName())
+			.birthDate(userJoinRequest.getBirthDate())
+			.phoneNumber(userJoinRequest.getPhoneNumber())
+			.interests(categorySet)
+			.gender(Gender.valueOf(userJoinRequest.getGender()))
+			.location(userJoinRequest.getLocation())
+			.nickname(userJoinRequest.getNickName())
 			.build();
 		userRepository.save(joinUser);
 	}
 
-	private void validateExistUser(UserJoinRequestDTO userJoinRequest) {
-		String email = userJoinRequest.getEmail();
+	public void validateExistEmail(String email) {
 		if (userRepository.existsByEmail(email)) {
 			throw ModongException.from(ErrorCode.DUPLICATE_USER_EMAIL);
+		}
+	}
+
+	public void validateExistNickname(String nickname) {
+		if (userRepository.existsByEmail(nickname)) {
+			throw ModongException.from(ErrorCode.DUPLICATE_USER_NICKNAME);
 		}
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserJoinService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserJoinService.java
@@ -1,5 +1,8 @@
 package com.goorm.insideout.user.service;
 
+import static com.goorm.insideout.global.exception.ErrorCode.*;
+
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -17,6 +20,7 @@ import com.goorm.insideout.user.dto.request.CheckNicknameRequest;
 import com.goorm.insideout.user.dto.request.UserJoinRequestDTO;
 import com.goorm.insideout.user.repository.UserRepository;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -47,6 +51,17 @@ public class UserJoinService {
 			.nickname(userJoinRequest.getNickName())
 			.build();
 		userRepository.save(joinUser);
+	}
+
+	public void checkFirstLogin(User user, HttpServletResponse response) throws IOException {
+		if(user==null){
+			throw ModongException.from(USER_NOT_FOUND);
+		}
+		String nickname= user.getNickname();
+		if(nickname==null){
+			response.sendRedirect("http://localhost:5173/userinfo");
+			//response.sendRedirect("https://modong.link/userinfo");
+		}
 	}
 
 	public void validateExistEmail(String email) {


### PR DESCRIPTION
### #️⃣ 연관된 이슈

#38

### 📝 작업 내용

1. 토큰 만료 판별을 못했던 기존 로직을 수정했습니다
2. 회원가입시 추가 입력 정보 받는 기능을 추가했습니다
3. 첫 소셜 로그인 시 정보입력 페이지로 리다이렉트 하는 기능을 추가했습니다

### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)

유저 엔티티를 인증과 정보로 분리하려 했지만.. 즉시로딩을 사용안하는점, 패치조인을 사용해야하는데 시큐리티 홀더에서 꺼낼때마다 코드가 너무 지저분해진다는 점 으로 득보다 실이 많은거 같아서 유저 앤티티 하나로 구현했습니다