### PR TITLE
모임 CRUD 기능 에러 수정

### DIFF
--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
@@ -44,9 +44,10 @@ public class MeetingController {
 		@RequestPart(value = "meetingImage", required = false) List<MultipartFile> multipartFiles,
 		@AuthenticationPrincipal CustomUserDetails customUserDetails
 	) {
-		meetingService.save(request, customUserDetails);
+		User user = customUserDetails.getUser();
+		meetingService.save(request, user);
 
-		return new ApiResponse<>("성공성공성공");
+		return new ApiResponse<>(ErrorCode.REQUEST_OK);
 	}
 
 	// 모임 단건 조회

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.goorm.insideout.auth.dto.CustomUserDetails;
@@ -23,6 +24,7 @@ import com.goorm.insideout.meeting.dto.request.MeetingCreateRequest;
 import com.goorm.insideout.meeting.dto.request.MeetingUpdateRequest;
 import com.goorm.insideout.meeting.dto.response.MeetingResponse;
 import com.goorm.insideout.meeting.service.MeetingService;
+import com.goorm.insideout.user.domain.User;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,6 +50,12 @@ public class MeetingController {
 		meetingService.save(request, user);
 
 		return new ApiResponse<>(ErrorCode.REQUEST_OK);
+	}
+
+	@GetMapping("/meetings")
+	@Operation(summary = "모임 전체 조회 API", description = "모임 전체를 조회할 수 있는 API 입니다.")
+	public ApiResponse<MeetingResponse> findAll() {
+		return new ApiResponse<>(meetingService.findAll());
 	}
 
 	// 모임 단건 조회

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/controller/MeetingController.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @Tag(name = "MeetingController", description = "모임 관련 API")

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/Meeting.java
@@ -147,8 +147,8 @@ public class Meeting {
 		meeting.hasMembershipFee = hasMembershipFee;
 		meeting.membershipFee = membershipFee;
 		meeting.hobby = hobby;
-		meeting.setHost(user);
-		meeting.setMeetingPlace(meetingPlace);
+		meeting.host = user;
+		meeting.meetingPlace = meetingPlace;
 
 		return meeting;
 	}
@@ -172,7 +172,7 @@ public class Meeting {
 		this.hasMembershipFee = meeting.hasMembershipFee;
 		this.membershipFee = meeting.membershipFee;
 		this.hobby = meeting.hobby;
-		this.setMeetingPlace(meeting.getMeetingPlace());
+		this.meetingPlace = meeting.getMeetingPlace();
 	}
 
 	/**
@@ -184,18 +184,5 @@ public class Meeting {
 
 	public void changeProgress(Progress progress) {
 		this.progress = progress;
-	}
-
-	/*
-	 * 연관관계 설정 메서드
-	 */
-	private void setHost(User user) {
-		this.host = user;
-		user.getRunningMeetings().add(this);
-	}
-
-	private void setMeetingPlace(MeetingPlace meetingPlace) {
-		this.meetingPlace = meetingPlace;
-		meetingPlace.getMeetings().add(this);
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingPlace.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/domain/MeetingPlace.java
@@ -1,15 +1,10 @@
 package com.goorm.insideout.meeting.domain;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,9 +32,6 @@ public class MeetingPlace {
 
 	@Column(name = "longitude")
 	private Double longitude;
-
-	@OneToMany(mappedBy = "meetingPlace", cascade = CascadeType.ALL)
-	private List<Meeting> meetings = new ArrayList<>();
 
 	/**
 	 * 생성 메서드

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/response/MeetingResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/dto/response/MeetingResponse.java
@@ -6,8 +6,10 @@ import java.util.List;
 import com.goorm.insideout.image.dto.response.ImageResponse;
 import com.goorm.insideout.meeting.domain.Meeting;
 import com.goorm.insideout.meeting.domain.MeetingPlace;
+import com.goorm.insideout.user.dto.response.HostResponse;
 import com.querydsl.core.annotations.QueryProjection;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,9 +20,7 @@ public class MeetingResponse {
 	// User 엔티티를 구현하지 않았으므로 임시 주석 처리
 	// private UserResponse user;
 	private String description;
-	private List<ImageResponse> images;
 	private String rule;
-	private String joinQuestion;
 	private int view;
 	private int like;
 	private boolean hasMembershipFee;
@@ -29,7 +29,6 @@ public class MeetingResponse {
 	private String level;
 	private String hobby;
 	private String category;
-	private MeetingPlaceResponse place;
 	private LocalDateTime schedule;
 	private int participantsNumber;
 	private int participantLimit;
@@ -37,6 +36,10 @@ public class MeetingResponse {
 	private int femaleRatio;
 	private int minimumAge;
 	private int maximumAge;
+	private String joinQuestion;
+	private HostResponse host;
+	private MeetingPlaceResponse place;
+	private List<ImageResponse> images;
 
 	@QueryProjection
 	public MeetingResponse(Meeting meeting) {
@@ -44,10 +47,6 @@ public class MeetingResponse {
 		// User 엔티티를 구현하지 않았으므로 임시 주석 처리
 		// this.user = new UserResponse(meeting.getAuthor());
 		this.description = meeting.getDescription();
-		this.images = meeting.getImages()
-			.stream()
-			.map(ImageResponse::new)
-			.toList();
 		this.rule = meeting.getRule();
 		this.joinQuestion = meeting.getJoinQuestion();
 		this.view = meeting.getView();
@@ -58,7 +57,6 @@ public class MeetingResponse {
 		this.level = meeting.getLevel().name();
 		this.hobby = meeting.getHobby();
 		this.category = meeting.getCategory().name();
-		this.place = new MeetingPlaceResponse().toDto(meeting.getMeetingPlace());
 		this.schedule = meeting.getSchedule();
 		this.participantsNumber = meeting.getParticipantsNumber();
 		this.participantLimit = meeting.getParticipantLimit();
@@ -66,31 +64,37 @@ public class MeetingResponse {
 		this.femaleRatio = meeting.getGenderRatio().getFemaleRatio();
 		this.minimumAge = meeting.getMinimumAge();
 		this.maximumAge = meeting.getMaximumAge();
+		this.host = HostResponse.fromEntity(meeting.getHost());
+		this.place = MeetingPlaceResponse.fromEntity(meeting.getMeetingPlace());
+		this.images = meeting.getImages()
+			.stream()
+			.map(ImageResponse::new)
+			.toList();
 	}
 
 	public static MeetingResponse from(Meeting meeting) {
 		return new MeetingResponse(meeting);
 	}
 
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PROTECTED)
 	public static class MeetingPlaceResponse {
 		private String name;
-
 		private String placeUrl;
-
 		private Long kakaoMapId;
-
 		private Double latitude;
-
 		private Double longitude;
 
-		private MeetingPlaceResponse toDto(MeetingPlace meetingPlace) {
-			this.name = meetingPlace.getName();
-			this.placeUrl = meetingPlace.getPlaceUrl();
-			this.kakaoMapId = meetingPlace.getKakaoMapId();
-			this.latitude = meetingPlace.getLatitude();
-			this.longitude = meetingPlace.getLongitude();
+		private static MeetingPlaceResponse fromEntity(MeetingPlace meetingPlace) {
+			MeetingPlaceResponse meetingPlaceResponse = new MeetingPlaceResponse();
 
-			return this;
+			meetingPlaceResponse.name = meetingPlace.getName();
+			meetingPlaceResponse.placeUrl = meetingPlace.getPlaceUrl();
+			meetingPlaceResponse.kakaoMapId = meetingPlace.getKakaoMapId();
+			meetingPlaceResponse.latitude = meetingPlace.getLatitude();
+			meetingPlaceResponse.longitude = meetingPlace.getLongitude();
+
+			return meetingPlaceResponse;
 		}
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
@@ -36,11 +36,7 @@ public class MeetingService {
 	private final UserRepository userRepository;
 
 	@Transactional
-	public Long save(MeetingCreateRequest request, CustomUserDetails customUserDetails) {
-		User user = userRepository.findById(customUserDetails.getUser().getId())
-			.orElseThrow(() -> ModongException.from(ErrorCode.USER_NOT_FOUND));
-		userRepository.save(user);
-
+	public Long save(MeetingCreateRequest request, User user) {
 		MeetingPlace meetingPlace = findOrCreatePlace(request.getMeetingPlace());
 		Meeting meeting = request.toEntity(user, meetingPlace);
 		meetingRepository.save(meeting);

--- a/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/meeting/service/MeetingService.java
@@ -1,5 +1,6 @@
 package com.goorm.insideout.meeting.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -42,6 +43,13 @@ public class MeetingService {
 		meetingRepository.save(meeting);
 
 		return meeting.getId();
+	}
+
+	public List<MeetingResponse> findAll() {
+		return meetingRepository.findAll()
+			.stream()
+			.map(MeetingResponse::from)
+			.toList();
 	}
 
 	public MeetingResponse findById(Long id) {

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
@@ -1,16 +1,10 @@
 package com.goorm.insideout.user.domain;
 
-
 import java.time.LocalDate;
 import java.util.Set;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.goorm.insideout.meeting.domain.Category;
-import com.goorm.insideout.meeting.domain.Meeting;
-import com.goorm.insideout.meeting.domain.MeetingUser;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
@@ -20,9 +14,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,7 +43,6 @@ public class User {
 
 	@Column(nullable = false)
 	private String name;
-
 
 	private String profileImage;
 

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
@@ -70,11 +70,4 @@ public class User {
 
 	@Enumerated(EnumType.STRING)
 	private Gender gender;
-  
-	@OneToMany(mappedBy = "host", cascade = CascadeType.ALL)
-	private List<Meeting> runningMeetings = new ArrayList<>();
-
-	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-	private List<MeetingUser> meetingUsers = new ArrayList<>();
-
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/response/HostResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/response/HostResponse.java
@@ -1,0 +1,22 @@
+package com.goorm.insideout.user.dto.response;
+
+import com.goorm.insideout.user.domain.User;
+
+import lombok.Getter;
+
+@Getter
+public class HostResponse {
+	private Long id;
+	private String nickname;
+	private String profileImage;
+
+	public static HostResponse fromEntity(User host) {
+		HostResponse hostResponse = new HostResponse();
+
+		hostResponse.id = host.getId();
+		hostResponse.nickname = host.getNickname();
+		hostResponse.profileImage = host.getProfileImage();
+
+		return hostResponse;
+	}
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #63 

### 📝 작업 내용

- 모임 CRUD 중에서 조회 쪽은 아예 응답이 안 오고, 생성의 경우 모임이 정상적으로 DB에 저장은 되지만 성공했다는 응답이 아닌 404 에러가 뜨는 상황이 발생했었습니다.
  - 이걸로 한 2주 고통받았는데 알고보니 `@RestController`를 안 쓰고 그냥 `@Controller`를 써서 그런 거였네요... 바꾸니까 바로 해결됐습니다 아 ㄹㅇ 허무하다 왜 이걸 못 찾았지

- 그 외에 `could not initialize proxy [] - no Session` 에러 발생 방지를 위해 엔티티에서의 양방향 연관관계를 제거하고 모두 단방향 연관관계로 바꾸었습니다.
  - 찾아보니까 원래 양방향 연관관계 자체가 좋은 건 아니라고 하네요.. 편리하긴 한데 진짜 필요할 때만 쓰는 게 좋다고 합니다!

- 모임 정보 조회 DTO에 원래 호스트 정보가 없었는데 추가했습니다.

- 기존에 없던 모임 전체 조회 API를 추가 구현했습니다.

### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)