### PR TITLE
fix: User 엔티티 일부 필드 제거

### DIFF
--- a/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/domain/User.java
@@ -64,12 +64,6 @@ public class User {
 
 	@Enumerated(EnumType.STRING)
 	private Gender gender;
-  
-	@OneToMany(mappedBy = "host", cascade = CascadeType.ALL)
-	private List<Meeting> runningMeetings = new ArrayList<>();
-
-	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-	private List<MeetingUser> meetingUsers = new ArrayList<>();
 
 	public void increaseMannerTemperature(){
 		BigDecimal temp = this.getMannerTemp().add(BigDecimal.valueOf(0.1));


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> #66 

### 📝 작업 내용

- `User` 엔티티 내부의 meetingUsers, runningMeetings 필드 제거
- 이후 서버 정상적으로 실행되는지 확인했습니다.

### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)