### PR TITLE
프로필 조회 로직 수정

### DIFF
--- a/Inside-Out/src/main/java/com/goorm/insideout/auth/filter/CustomOAuthLoginHandler.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/auth/filter/CustomOAuthLoginHandler.java
@@ -40,8 +40,8 @@ public class CustomOAuthLoginHandler extends SimpleUrlAuthenticationSuccessHandl
 		refreshTokenRepository.save(refreshToken);
 		// reissue 요청으로 리다이렉트하기
 		//response.sendRedirect("http://localhost:3000/?action=reissue");
-		response.sendRedirect("http://localhost:5173/reissue");
-		//response.sendRedirect("https://modong.link/reissue");
+		// response.sendRedirect("http://localhost:5173/reissue");
+		response.sendRedirect("https://modong.link/reissue");
 	}
 	private ResponseCookie createCookie(String key, String value) {
 		return ResponseCookie.from(key, value)

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserProfileController.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/controller/UserProfileController.java
@@ -22,6 +22,7 @@ import com.goorm.insideout.image.domain.ProfileImage;
 import com.goorm.insideout.image.service.ImageService;
 import com.goorm.insideout.user.domain.User;
 import com.goorm.insideout.user.dto.request.ProfileUpdateRequest;
+import com.goorm.insideout.user.dto.response.MyProfileResponse;
 import com.goorm.insideout.user.dto.response.ProfileResponse;
 import com.goorm.insideout.user.repository.UserRepository;
 import com.goorm.insideout.user.service.UserProfileService;
@@ -57,10 +58,10 @@ public class UserProfileController {
 
 	@GetMapping()
 	@Operation(summary = "사용자 프로필 확인 API", description = "사용자 프로필를 확인할 수 있는 API 입니다.")
-	public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
-		ProfileResponse profile = userProfileService.getProfile(customUserDetails.getUser());
+	public ApiResponse<MyProfileResponse> getMyProfile(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		MyProfileResponse profile = userProfileService.getMyProfile(customUserDetails.getUser());
 
-		return new ApiResponse<ProfileResponse>(profile);
+		return new ApiResponse<MyProfileResponse>(profile);
 	}
 
 	@PatchMapping("/{userId}")

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/ProfileUpdateRequest.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/request/ProfileUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.goorm.insideout.user.dto.request;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 
 import lombok.Getter;
@@ -8,5 +10,6 @@ import lombok.Getter;
 public class ProfileUpdateRequest {
 	private String nickname;
 	private String password;
+	private List<String> interests;
 
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/response/MyProfileResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/response/MyProfileResponse.java
@@ -1,0 +1,43 @@
+package com.goorm.insideout.user.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import com.goorm.insideout.meeting.domain.Category;
+import com.goorm.insideout.user.domain.Gender;
+import com.goorm.insideout.user.domain.User;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MyProfileResponse {
+	private Long userId;
+	private String email;
+	private String profileImage;
+	private String nickname;
+	private BigDecimal mannerRating;
+	private Gender gender;
+	private String phoneNumber;
+	private LocalDate birthDate;
+	private Set<Category> interests;
+	private Set<String> locations;
+	private List<ProfileMeetingResponse> pendingMeetings;
+	private List<ProfileMeetingResponse> attendedMeetings;
+	private List<ProfileMeetingResponse> closedMeetings;
+	public MyProfileResponse(User user){
+		this.userId=user.getId();
+		this.email=user.getEmail();
+		this.profileImage=user.getProfileImage().getImage().getUrl();
+		this.nickname=user.getNickname();
+		this.mannerRating=user.getMannerTemp();
+		this.gender=user.getGender();
+		this.phoneNumber= user.getPhoneNumber();;
+		this.birthDate=user.getBirthDate();
+		this.interests=user.getInterests();
+		this.locations=user.getLocations();
+	}
+}

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/dto/response/MyProfileResponse.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/dto/response/MyProfileResponse.java
@@ -23,8 +23,8 @@ public class MyProfileResponse {
 	private Gender gender;
 	private String phoneNumber;
 	private LocalDate birthDate;
-	private Set<Category> interests;
-	private Set<String> locations;
+	private List<Category> interests;
+	private List<String> locations;
 	private List<ProfileMeetingResponse> pendingMeetings;
 	private List<ProfileMeetingResponse> attendedMeetings;
 	private List<ProfileMeetingResponse> closedMeetings;
@@ -37,7 +37,7 @@ public class MyProfileResponse {
 		this.gender=user.getGender();
 		this.phoneNumber= user.getPhoneNumber();;
 		this.birthDate=user.getBirthDate();
-		this.interests=user.getInterests();
-		this.locations=user.getLocations();
+		this.interests=user.getInterests().stream().toList();
+		this.locations=user.getLocations().stream().toList();
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserProfileService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserProfileService.java
@@ -1,7 +1,9 @@
 package com.goorm.insideout.user.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -12,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.goorm.insideout.auth.dto.CustomUserDetails;
 import com.goorm.insideout.image.domain.ProfileImage;
 import com.goorm.insideout.image.service.ImageService;
+import com.goorm.insideout.meeting.domain.Category;
 import com.goorm.insideout.meeting.dto.response.MeetingResponse;
 import com.goorm.insideout.meeting.service.MeetingService;
 import com.goorm.insideout.user.domain.User;
@@ -34,11 +37,15 @@ public class UserProfileService {
 	public void updateMyProfile(ProfileUpdateRequest profileUpdateRequest, User user) {
 		String password = profileUpdateRequest.getPassword();
 		String nickname = profileUpdateRequest.getNickname();
+		List<String> interests = profileUpdateRequest.getInterests();
 		if (password != null) {
 			user.setPassword(bCryptPasswordEncoder.encode(password));
 		}
 		if (nickname != null) {
 			user.setNickname(nickname);
+		}
+		if (!interests.isEmpty()) {
+			user.setInterests(stringListToCategorySet(interests));
 		}
 		userRepository.save(user);
 	}
@@ -74,5 +81,13 @@ public class UserProfileService {
 			profileMeetingResponses.add(new ProfileMeetingResponse(meetingResponse));
 		}
 		return profileMeetingResponses;
+	}
+
+	private Set<Category> stringListToCategorySet(List<String> categoryDTO) {
+		Set<Category> categorySet = new HashSet<>();
+		for (String category : categoryDTO) {
+			categorySet.add(Category.valueOf(category));
+		}
+		return categorySet;
 	}
 }

--- a/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserProfileService.java
+++ b/Inside-Out/src/main/java/com/goorm/insideout/user/service/UserProfileService.java
@@ -19,6 +19,7 @@ import com.goorm.insideout.meeting.dto.response.MeetingResponse;
 import com.goorm.insideout.meeting.service.MeetingService;
 import com.goorm.insideout.user.domain.User;
 import com.goorm.insideout.user.dto.request.ProfileUpdateRequest;
+import com.goorm.insideout.user.dto.response.MyProfileResponse;
 import com.goorm.insideout.user.dto.response.ProfileMeetingResponse;
 import com.goorm.insideout.user.dto.response.ProfileResponse;
 import com.goorm.insideout.user.repository.UserRepository;
@@ -62,6 +63,23 @@ public class UserProfileService {
 	public ProfileResponse getProfile(User user) {
 		User findUser = userRepository.findByIdWithProfileImage(user.getId());
 		ProfileResponse response = new ProfileResponse(findUser);
+
+		List<MeetingResponse> pendingMeetings = meetingService.findPendingMeetings(findUser);
+		response.setPendingMeetings(meetingResponseToProfile(pendingMeetings));
+
+		List<MeetingResponse> ParticipatingMeetings = meetingService.findParticipatingMeetings(findUser);
+		response.setAttendedMeetings(meetingResponseToProfile(ParticipatingMeetings));
+
+		List<MeetingResponse> endedMeetings = meetingService.findEndedMeetings(findUser);
+		response.setClosedMeetings(meetingResponseToProfile(endedMeetings));
+
+		return response;
+	}
+
+	@Transactional
+	public MyProfileResponse getMyProfile(User user) {
+		User findUser = userRepository.findByIdWithProfileImage(user.getId());
+		MyProfileResponse response = new MyProfileResponse(findUser);
 
 		List<MeetingResponse> pendingMeetings = meetingService.findPendingMeetings(findUser);
 		response.setPendingMeetings(meetingResponseToProfile(pendingMeetings));


### PR DESCRIPTION
### #️⃣ 연관된 이슈



### 📝 작업 내용
1. 관심사 수정 가능하도록 변경
2. 본인 프로필 조회시 전화번호, 성별, 생년월일, 관심사, 지역, 이메일 추가  ( 다른 사용자 프로필은 현행유지)
3. 소셜 로그인시 토큰 재발급 url 프론트 배포 서버로 변경


### 📷 스크린샷 (선택)

### 💬 리뷰 요구사항 (선택)
